### PR TITLE
activate mknemo unsio && uns_projects

### DIFF
--- a/src/scripts/mknemo.d/uns_projects
+++ b/src/scripts/mknemo.d/uns_projects
@@ -13,11 +13,21 @@ set dir=$NEMO/usr/jcl/uns_projects
 # for linux
 set args=""
 
+#check unsio is installed
+if (! -f ${NEMOLIB}64/libunsio.so && ! -f ${NEMOLIB}/libunsio.so ) then
+	mknemo -r unsio
+endif
+
+if (! -e $dir) then
+  cd $NEMO/usr/jcl
+  git clone https://gitlab.lam.fr/jclamber/uns_projects
+endif
 
 if (-e $dir) then
+  rm -rf $dir/build
   mkdir -p $dir/build
   cd $dir/build
-  cmake ..
+  cmake .. -DCMAKE_INSTALL_PREFIX=${NEMO}
   make
   make install
 else

--- a/src/scripts/mknemo.d/unsio
+++ b/src/scripts/mknemo.d/unsio
@@ -20,7 +20,6 @@
 #  -DBUILD_SHARED_LIBS=<TRUE|FALSE>      shared or static libraries [TRUE]
 #  -DCMAKE_DISABLE_FORTRAN=1
 
-
 set dir=$NEMO/usr/jcl/unsio
 
 # for linux
@@ -36,17 +35,23 @@ else
   set h5=()
 endif
 
-if (-e $dir) then
+if ( ! -e ${dir} ) then
+  #echo "mknemo.d: $dir does not exist; try"
+  #echo '    (cd $NEMO/usr/jcl; make unsio; mknemo unsio)'
+  # we clone first time
+  cd $NEMO/usr/jcl
+  git clone https://gitlab.lam.fr/jclamber/unsio
+endif
+
+if ( -e $dir ) then
   rm -rf $dir/build
   mkdir -p $dir/build
   cd $dir/build
   cmake -DCMAKE_INSTALL_PREFIX=$NEMO $h5 ..
   make
   make install
-else
-  echo "mknemo.d: $dir does not exist; try"
-  echo '    (cd $NEMO/usr/jcl; make unsio; mknemo unsio)'
 endif
+
 
 echo Warning:  python interface is not yet installed. See $NEMO/usr/jcl/unsio/py/INSTALL
 echo Basically:   pip install python-unsio


### PR DESCRIPTION
Hi Peter,
I have modified src/scripts/mknemo.d/unsio && uns_projects to compile this 2 projects.
The only requirement is to have `cmake` tools + `hdf5 dev` files. Then it should compile.

A simple `mknemo uns_projects` would compile and install unsio lib, and also compile all uns_projects binaries 
- uns2uns : convert uns files (nemo, ramses, gadget2, gadget3) to (nemo, gadget2, gadget3)
- uns_density : to compute density using falcON (most wanted programs)
- uns_2dplot, etc.....
These binaries are moved automatically into NEMOBIN.

Could you try by yourself ?