### PR TITLE
Use package name for gala

### DIFF
--- a/src/scripts/install_anaconda3
+++ b/src/scripts/install_anaconda3
@@ -76,8 +76,8 @@ else
 endif
 
 # https://github.com/adrn/gala
-# conda install astro-gala --channel conda-forge
-pip install astro-gala
+# conda install gala --channel conda-forge
+pip install gala
 
 # https://github.com/jobovy/galpy
 #


### PR DESCRIPTION
I was searching github for instances of "astro-gala" and came across this! I recently got access to the name "gala," so to simplify, I changed the pypi and conda name of gala from astro-gala to gala.