### PR TITLE
Various regex fixes/ improvements

### DIFF
--- a/src/scripts/checkpars.py
+++ b/src/scripts/checkpars.py
@@ -36,14 +36,14 @@ def get_man_matches(file):
 
         # Scans parameters
         if containsParameters:
-            if re.search(r'\.TP',line): # If we encounter a .TP, scan next line for a command
+            if re.search(r'^\.TP',line): # If we encounter a .TP, scan next line for a command
                 scan_flag = True
             elif scan_flag: #\\fB(\w|#)*= \\f[a-zA-Z][a-zA-Z]+[0-9]*
-                match = re.findall(r'\\fB[\w|#|/]*=',line)
+                match = re.findall(r'\\fB([\w|#|/]*)=',line)
                 if not match: # If the .TP isn't followed by a command, flag file as bad
                     return 'Non-conformant: ' + line
                 else:
-                    man_matches.append(match[0][3:-1])
+                    man_matches.append(match[0])
                 scan_flag = False
 
     man_doc.close()


### PR DESCRIPTION
Added a ^ to .TP scan so it forces the line to start with a .TP but it can still be followed by other stuff like ".TP 20"
Changed parameter parsing with parentheses which capture only the stuff we want. This lets us avoid splitting the string after parsing. Will update the other regex's for .SH parsing and help parsing to make everything uniform.