### PR TITLE
fix IMF from Eggleton book

### DIFF
--- a/src/nbody/evolve/aarseth/nbody4/imf.f
+++ b/src/nbody/evolve/aarseth/nbody4/imf.f
@@ -147,7 +147,7 @@
  35      XX = RAN2(KDUM)
 *
          IF(KZ(20).EQ.3)THEN
-            ZM = 0.3D0*XX/(1.D0 - XX)**0.55
+            ZM = 0.3D0*(XX/(1.D0 - XX))**0.55
          ELSEIF(KZ(20).EQ.4.OR.KZ(20).EQ.5)THEN
             XX1 = 1.0 - XX
             IF(KZ(20).EQ.5.AND.I.LE.NBIN0)THEN


### PR DESCRIPTION
There is an option in Nbody4 to generate masses according to Eggleton book. As I understood, they imply this one: Peter Eggleton, "Evolutionary Processes in Binary and Multiple Stars", https://doi.org/10.1017/CBO9780511536205

In this book, section 1.6, there is a slightly different expression: `0.3 (u / (1-u))**0.5` instead of `0.3 u / (1-u)**0.5`.

I made a small script to demonstrate the difference:

```python
import numpy as np
import matplotlib.pyplot as plt

u = np.random.uniform(size=5000)

def f_nbody(u):
    return 0.3 * u / (1 - u)**0.55

def f_book(u):
    return 0.3 * (u / (1 - u))**0.55

bins = np.logspace(-5, 1)

m_nbody = f_nbody(u)
m_book = f_book(u)

plt.hist(m_nbody, bins=bins, color='r');
plt.hist(m_book, bins=bins, color='b');
plt.xscale('log')

plt.show()

print(np.max(m_nbody), np.min(m_nbody))
print(np.max(m_book), np.min(m_book))
```

![изображение](https://github.com/user-attachments/assets/af8817ab-b5b6-464c-8f52-b1c1b9d509f6)

If masses in formula are given in Solar masses, we get too small mass from the current IMF, right?

Is this a bug? idk maybe it's not that important, but I decided to make a PR.
Also it is not fixed in Nbody6 (both versions from Aarseth site and GPU repo)