### PR TITLE
Falcon stdc++17

### DIFF
--- a/docs/whatsnew.html
+++ b/docs/whatsnew.html
@@ -23,7 +23,9 @@ contains a timestamp of that creation.
 
 <A NAME=4_5_0>
   <H2> 4.5.x:  in git (a.k.a. the Aarseth Release) </H2>
-  <UL>
+  <UL> 
+    <LI> (Aug 26, 2025) gyrfalcON 3.7 now compiles with stdc++11 (stdc++17 upcoming too)
+    <LI> (Aug 26, 2025) fixed KZ(20)=3 typo in nbody4
     <LI> (Jul 2, 2025) some AGAMA supporting tests in NEMO/usr/agama
     <LI> (Jun 19, 2025) fixed 64bit issue with fits files, advice is to recompile library as well
     <LI> (June 6, 2025)  new <A HREF=man_html/ccdcross.1.html>ccdcross</A> to estimate

--- a/inc/defacc.h
+++ b/inc/defacc.h
@@ -379,7 +379,7 @@ namespace {
 	try {
 	  Pars = new double[npar];
 	} catch(std::bad_alloc& E) {
-	  error("[%s:%d]: caught std::bad_alloc\n",__FILE__,__LINE__);
+	  error((char*) "[%s:%d]: caught std::bad_alloc\n",__FILE__,__LINE__);
 	}
 	for(int n=0; n!=npar; ++n) Pars[n] = pars[n];
       } else
@@ -391,7 +391,7 @@ namespace {
 	try {
 	  File = new char[n];
 	} catch(std::bad_alloc& E) {
-	  error("[%s:%d]: caught std::bad_alloc\n",__FILE__,__LINE__);
+	  error((char*) "[%s:%d]: caught std::bad_alloc\n",__FILE__,__LINE__);
 	}
 	strncpy(File,file,n);
       } else
@@ -418,7 +418,7 @@ namespace {
 	  Acc.template set_time<3>(Time,nbod,mas,pos,vel);
 	  break;
 	default:
-	  ::error("acceleration: ndim=%d not supported", ndim);
+	  ::error((char *) "acceleration: ndim=%d not supported", ndim);
 	}
       }
     }
@@ -496,12 +496,12 @@ namespace {
       if(need_mass)
 	*need_mass = Acc.NeedMass();
       else if(Acc.NeedMass())
-	::error("inipotential: cannot use \"%s\", since masses are needed",
+	::error((char *) "inipotential: cannot use \"%s\", since masses are needed",
 		Acceleration::name());
       if(need_vels)
 	*need_vels = Acc.NeedVels();
       else if(Acc.NeedVels())
-	::error("inipotential: cannot use \"%s\", since velocities are needed",
+	::error((char *) "inipotential: cannot use \"%s\", since velocities are needed",
 		Acceleration::name());
     }
     //--------------------------------------------------------------------------
@@ -547,7 +547,7 @@ namespace {
 				  static_cast<double*>(p),
 				  static_cast<double*>(a),
 				  add);
-	default: ::error("acceleration \"%s\": unknown type ('%s')",
+	default: ::error((char *) "acceleration \"%s\": unknown type ('%s')",
 			 Acceleration::name(),type);
 	} break;
       case 3:
@@ -568,10 +568,10 @@ namespace {
 				  static_cast<double*>(p),
 				  static_cast<double*>(a),
 				  add);
-	default: ::error("acceleration \"%s\": unknown type ('%s')",
+	default: ::error((char *) "acceleration \"%s\": unknown type ('%s')",
 			 Acceleration::name(),type);
 	} break;
-      default: ::error("acceleration \"%s\": ndim=%d unsupported",
+      default: ::error((char *) "acceleration \"%s\": ndim=%d unsupported",
 		       Acceleration::name(),nd);
       }
     }
@@ -595,7 +595,7 @@ namespace {
       case 3: Acc.template acc<3>(static_cast<const scalar*>(0), __pos, 
 				  static_cast<const scalar*>(0), *__pot, __acc);
 	break;
-      default: ::error("potential \"%s\": ndim=%d not supported",
+      default: ::error((char *) "potential \"%s\": ndim=%d not supported",
 		       Acceleration::name(),__ndim);
       }
     }
@@ -667,7 +667,7 @@ void iniacceleration(const double*pars,					\
 {									\
   nemo_dprintf(4,"iniacceleration() called\n");				\
   if(AccN == AccMax) {							\
-    ::warning("iniacceleration(): request to initialize "		\
+    ::warning((char *) "iniacceleration(): request to initialize "		\
 	      "more than %d accelerations of type \"%s\"",		\
 	      AccMax, MyAccInstall::name());				\
     *accel = 0;								\
@@ -676,7 +676,7 @@ void iniacceleration(const double*pars,					\
   try {									\
     MyAcc[AccN] = new MyAccInstall(pars,npar,file,need_m,need_v);	\
   } catch(std::bad_alloc& E) {						\
-    ::error("[%s:%d]: caught std::bad_alloc\n",__FILE__,__LINE__);	\
+    ::error((char *) "[%s:%d]: caught std::bad_alloc\n",__FILE__,__LINE__);	\
   }									\
   *accel = Accs[AccN++];						\
 }
@@ -703,11 +703,11 @@ void inipotential(const int   *npar,					\
 {									\
   if(MyPot) {								\
     if(MyPot->differ(pars,*npar,file))					\
-      ::warning("inipotential(): re-initializing \"%s\" "		\
+      ::warning((char *) "inipotential(): re-initializing \"%s\" "		\
 		"with different parameters or data file",		\
 		MyPotInstall::name());					\
     else								\
-      ::warning("inipotential(): re-initializing \"%s\" "		\
+      ::warning((char *) "inipotential(): re-initializing \"%s\" "		\
 		"with identical parameters and data file",		\
 		MyPotInstall::name());					\
     delete MyPot;							\
@@ -715,7 +715,7 @@ void inipotential(const int   *npar,					\
   try {									\
     MyPot = new MyPotInstall(pars,*npar,file,0,0);			\
   } catch(std::bad_alloc& E) {						\
-    ::error("[%s:%d]: caught std::bad_alloc\n",__FILE__,__LINE__);	\
+    ::error((char *) "[%s:%d]: caught std::bad_alloc\n",__FILE__,__LINE__);	\
   }									\
 }									\
 void potential_double(const int   *ndim,				\

--- a/man/man1/gyrfalcON.1
+++ b/man/man1/gyrfalcON.1
@@ -324,5 +324,5 @@ Walter Dehnen
 27-sep-2005	version 3.0.4 of gyrfalcON WD
 28-feb-2007     version 3.0.9 of gyrfalcON WD
 21-apr-2024	notes on griffin and falcon	PJT
-6-oct-2025	V3.8 to be released	JCL
+7-oct-2025	std++11 support as V3.7		JCL
 .fi

--- a/man/man1/gyrfalcON.1
+++ b/man/man1/gyrfalcON.1
@@ -1,4 +1,4 @@
-.TH gyrfalcON 1falcON "28 February 2007"
+.TH gyrfalcON 1falcON "6 October 2025"
 
 .SH "NAME"
 gyrfalcON \- a superberb N-body code (public version)
@@ -314,7 +314,7 @@ falcON/doc/user_guide.pdf                         \fIUser Guide for falcON\fP
 
 .SH "AUTHOR"
 .nf
-Walter Dehnen                              walter.dehnen@astro.le.ac.uk
+Walter Dehnen
 
 .SH "HISTORY"
 .nf
@@ -324,4 +324,5 @@ Walter Dehnen                              walter.dehnen@astro.le.ac.uk
 27-sep-2005	version 3.0.4 of gyrfalcON WD
 28-feb-2007     version 3.0.9 of gyrfalcON WD
 21-apr-2024	notes on griffin and falcon	PJT
+6-oct-2025	V3.8 to be released	JCL
 .fi

--- a/usr/dehnen/falcON/inc/acc/GalPot.cc
+++ b/usr/dehnen/falcON/inc/acc/GalPot.cc
@@ -77,7 +77,7 @@ namespace GalPot {                                  // v0.4
   template <class ALLOCTYPE>
   inline int Alloc2D(ALLOCTYPE** &A, const int N[2])
   {
-    register int i, iN1;
+     int i, iN1;
     A    = new ALLOCTYPE*[N[0]];	 if(!A) return 1;
     A[0] = new ALLOCTYPE [N[0]*N[1]];  if(!A[0]) return 1;
     for(i=1, iN1=N[1]; i<N[0]; i++,iN1+=N[1])
@@ -193,8 +193,8 @@ namespace GalPot {                                  // v0.4
 	      int const natn=0)	// input:   natural spline at x[n-1] ?
   { 
     const S  zero=0., half=0.5, one=1., two=2., three=3., six=6.;
-    register int i;
-    register S   qn,p,sig,dx,dx1,dx2;
+     int i;
+     S   qn,p,sig,dx,dx1,dx2;
     T   un,dy,dy1;
     T *u = new T[n-1];
     S *v = new S[n-1];
@@ -246,24 +246,24 @@ namespace GalPot {                                  // v0.4
   {
     // computes K splines simultaneously
     const    S   zero=0., one=1., three=3., six=6.;
-    register T   *Y=y, *Yl=yl, *Yh=yh, *Y2l=y2l, *Y2h=y2h, *YK=y+K;
-    register S   h,h6,hh,A,B,Aq,Bq,Ap,Bp;
+     T   *Y=y, *Yl=yl, *Yh=yh, *Y2l=y2l, *Y2h=y2h, *YK=y+K;
+     S   h,h6,hh,A,B,Aq,Bq,Ap,Bp;
     if((h=xh-xl)==zero) error("splinTarr bad X input");
     h6=h/six;
     hh=h*h6;
     A =(xh-xi)/h;  Aq=A*A;  Ap=(Aq-one)*A*hh;
     B =one-A;      Bq=B*B;  Bp=(Bq-one)*B*hh;
     if(d2y) {
-      register T *dY=dy, *d2Y=d2y;
-      register S Au=h6*(three*Aq-one), Bu=h6*(three*Bq-one);
+       T *dY=dy, *d2Y=d2y;
+       S Au=h6*(three*Aq-one), Bu=h6*(three*Bq-one);
       for(; Y<YK; Y++,Yl++,Yh++,Y2l++,Y2h++,dY++,d2Y++) {
 	*Y   = A**Yl+B**Yh+Ap**Y2l+Bp**Y2h;
 	*dY  = (*Yh-*Yl)/h + Bu**Y2h-Au**Y2l;
 	*d2Y = A**Y2l + B**Y2h;
       }
     } else if(dy) {
-      register T *dY=dy;
-      register S Au=h6*(three*Aq-one), Bu=h6*(three*Bq-one);
+       T *dY=dy;
+       S Au=h6*(three*Aq-one), Bu=h6*(three*Bq-one);
       for(; Y<YK; Y++,Yl++,Yh++,Y2l++,Y2h++,dY++) {
 	*Y   = A**Yl+B**Yh+Ap**Y2l+Bp**Y2h;
 	*dY  = (*Yh-*Yl)/h + Bu**Y2h-Au**Y2l;
@@ -287,9 +287,9 @@ namespace GalPot {                                  // v0.4
   // value at the grid points. At the grid boundaries  d^3y/dx^3=0  is adopted.
   {
     const S      zero=0.,one=1.,three=3.,seven=7.,ten=10.,twelve=12.; 
-    register int i;
-    register S   p,sig,dx,dx1,dx2;
-    register T   dy=Y[1]-Y[0], dy1=dy;
+     int i;
+     S   p,sig,dx,dx1,dx2;
+     T   dy=Y[1]-Y[0], dy1=dy;
     S *v = new S[n-1];
     dx   = x[1]-x[0];
     Y3[0]= v[0] = zero;
@@ -328,7 +328,7 @@ namespace GalPot {                                  // v0.4
 	    T* d2Yi=0)			// output:  d^2y/d^2x(xi) if d2y != 0
   {
     const    S zero=0.,one=1.,two=2.,five=5.,six=6.,nine=9.,fe=48.;
-    register S h,hi,hf, A,B,C,D,Aq,Bq;
+     S h,hi,hf, A,B,C,D,Aq,Bq;
     if((h=x1-x0)==zero) error("PsplinT bad X input");
     hi = one/h;
     hf = h*h;
@@ -336,17 +336,17 @@ namespace GalPot {                                  // v0.4
     B  = one-A;      Bq = B*B;
     C  = h*Aq*B;
     D  =-h*Bq*A;
-    register T 	t1 = hi*(Y1-Y0),
+     T 	t1 = hi*(Y1-Y0),
       C2 = Y10-t1,
       C3 = Y11-t1,
       t2 = six*(Y10+Y11-t1-t1)/hf,
       C4 = Y30-t2,
       C5 = Y31-t2;
     hf/= fe;
-    register T 	Yi = A*Y0+ B*Y1+ C*C2+ D*C3+ 
+     T 	Yi = A*Y0+ B*Y1+ C*C2+ D*C3+ 
       hf*(C*(Aq+Aq-A-one)*C4+ D*(Bq+Bq-B-one)*C5);
     if(dYi) {
-      register S BAA=B-A-A, ABB=A-B-B;
+       S BAA=B-A-A, ABB=A-B-B;
       hf  += hf;
       *dYi = t1 + (A*ABB)*C2 + (B*BAA)*C3
 	+ hf*A*B*((one+A-five*Aq)*C4+ (one+B-five*Bq)*C5);
@@ -377,9 +377,9 @@ namespace GalPot {                                  // v0.4
 		  T* d2y=0)		// output:  d^2y_k/d^2x(xi) if d2y != 0
   {
     const    S zero=0.,one=1.,two=2.,five=5.,six=6.,nine=9.,fe=48.;
-    register S h,hi,hq,hf, A,B,C,D,E,F,Aq,Bq;
-    register T C2=*yl,C3=C2,C4=C2,C5=C2, t1=C2,t2=C2;
-    register T *Y=y,*Yl=yl,*Yh=yh,*Y1l=y1l,*Y1h=y1h,*Y3l=y3l,*Y3h=y3h,*YK=y+K;
+     S h,hi,hq,hf, A,B,C,D,E,F,Aq,Bq;
+     T C2=*yl,C3=C2,C4=C2,C5=C2, t1=C2,t2=C2;
+     T *Y=y,*Yl=yl,*Yh=yh,*Y1l=y1l,*Y1h=y1h,*Y3l=y3l,*Y3h=y3h,*YK=y+K;
     if((h=xh-xl)==zero) error("PsplinTarr(): bad X input");
     hi = one/h;
     hq = h*h;
@@ -391,11 +391,11 @@ namespace GalPot {                                  // v0.4
     E  = hf*C*(Aq+Aq-A-one);
     F  = hf*D*(Bq+Bq-B-one);
     if(d2y) {
-      register S hf2= hf+hf, BAA=B-A-A, ABB=A-B-B,
+       S hf2= hf+hf, BAA=B-A-A, ABB=A-B-B,
 	AB=A*B, ABh=hf2*AB, Cp=Aq-AB-AB, Dp=Bq-AB-AB,
 	Ep=ABh*(one+A-five*Aq), Fp=ABh*(one+B-five*Bq),
 	Epp=hf2*(two*Aq*(nine*B-A)-one), Fpp=hf2*(two*Bq*(B-nine*A)+one);
-      register T *dY=dy, *d2Y=d2y;
+       T *dY=dy, *d2Y=d2y;
       for(; Y<YK; Y++,Yl++,Yh++,Y1l++,Y1h++,Y3l++,Y3h++,dY++,d2Y++) {
 	t1   = hi*(*Yh-*Yl);
 	C2   = *Y1l-t1;
@@ -410,9 +410,9 @@ namespace GalPot {                                  // v0.4
 	*d2Y*= hi;
       }
     } else if(dy) {
-      register S AB=A*B, ABh=(hf+hf)*AB, Cp=Aq-AB-AB, Dp=Bq-AB-AB,
+       S AB=A*B, ABh=(hf+hf)*AB, Cp=Aq-AB-AB, Dp=Bq-AB-AB,
 	Ep=ABh*(one+A-five*Aq), Fp=ABh*(one+B-five*Bq);
-      register T *dY=dy;
+       T *dY=dy;
       for(; Y<YK; Y++,Yl++,Yh++,Y1l++,Y1h++,Y3l++,Y3h++,dY++) {
 	t1  = hi*(*Yh-*Yl);
 	C2  = *Y1l-t1;
@@ -444,9 +444,9 @@ namespace GalPot {                                  // v0.4
 		 T** a[4])        // output: tables: coeffs a[0],a[1],a[2],a[3]
   {
     // 2D Pspline with natural boundary conditions
-    register   T   z=y[0][0][0];
+       T   z=y[0][0][0];
     z = 0.;
-    register int i,j;
+     int i,j;
     T *t = new T[n[0]];
     T *t1= new T[n[0]];
     T *t3= new T[n[0]];
@@ -485,7 +485,7 @@ namespace GalPot {                                  // v0.4
     static int l0=0, l1=0;
     find(l0,n[0],x[0],xi[0]);
     find(l1,n[1],x[1],xi[1]);
-    register int k0=l0+1, k1=l1+1;
+     int k0=l0+1, k1=l1+1;
 
     T fl[2] ={y[0][l0][l1], y[0][k0][l1]}, fh[2] ={y[0][l0][k1], y[0][k0][k1]},
       f1l[2]={y[2][l0][l1], y[2][k0][l1]}, f1h[2]={y[2][l0][k1], y[2][k0][k1]},
@@ -525,8 +525,8 @@ namespace GalPot {                                  // v0.4
     // based on a routine from J.J. Binney
     // evaluates even Legendre Polys up to l=2*(N-1) at x
   {
-    register int    n,l,l2;
-    register double x2=x*x;
+     int    n,l,l2;
+     double x2=x*x;
     p[0] = 1.;
     p[1] = 1.5*x2-0.5;
     for(n=2; n<N; n++) {
@@ -543,8 +543,8 @@ namespace GalPot {                                  // v0.4
     // based on a routine from J.J. Binney
     // evaluates even Legendre Polys and its derivs up to l=2*(N-1) at x
   {
-    register int    n,l,l2;
-    register double x2=x*x;
+     int    n,l,l2;
+     double x2=x*x;
     p[0] = 1.;
     d[0] = 0.;
     p[1] = 1.5*x2-0.5;
@@ -711,7 +711,7 @@ namespace GalPot {                                  // v0.4
 
   double I0(const double x)
   {
-    register double ax=abs(x),y;
+     double ax=abs(x),y;
     if(ax < 3.75) {
       y = x/3.75;
       y*= y;
@@ -727,7 +727,7 @@ namespace GalPot {                                  // v0.4
 
   double I1(const double x)
   {
-    register double ans,ax=abs(x),y;
+     double ans,ax=abs(x),y;
     if(ax < 3.75) {
       y = x/3.75;
       y*= y;
@@ -747,7 +747,7 @@ namespace GalPot {                                  // v0.4
   double K0(const double x)
   {
     if(x<0.) error("negative argument in K0(x)");
-    register double y;
+     double y;
     if(x <= 2.) {
       y = x*x/4.;
       return (-log(x/2.0)*I0(x))+(-0.57721566+y*(0.42278420
@@ -763,7 +763,7 @@ namespace GalPot {                                  // v0.4
   double K1(const double x)
   {
     if(x<0.) error("negative argument in K1(x)");
-    register double y;
+     double y;
     if(x <= 2.) {
       y=x*x/4.0;
       return (log(x/2.0)*I1(x))+(1.0/x)*(1.0+y*(0.15443144
@@ -782,8 +782,8 @@ namespace GalPot {                                  // v0.4
     if(x<0.) error("negative argument in Kn(x)");
     if(n==0) return K0(x);
     if(n==1) return K1(x);
-    register int j;
-    register double bk,bkm,bkp,tox;
+     int j;
+     double bk,bkm,bkp,tox;
 
     tox = 2./x;
     bkm = K0(x);
@@ -900,14 +900,14 @@ double DiskAnsatz::Residual(double r, double st, double ct) const
 // gives aimed Laplace(Phi_multipole)
 {
   if(ct==0. || S0==0.) return 0;
-  register double R=r*st, z=r*ct, g,gp,gpp, F,f,fp,fpp;
+   double R=r*st, z=r*ct, g,gp,gpp, F,f,fp,fpp;
   // deal with the vertical part
   if(thin) {
     g   = abs(z);
     gp  = sign(z);
     gpp = 0.;
   } else if(isothermal) {
-    register double x,sh1;
+     double x,sh1;
     x   = abs(z/zd);
     gpp = exp(-x);
     sh1 = 1.+gpp;
@@ -915,7 +915,7 @@ double DiskAnsatz::Residual(double r, double st, double ct) const
     gp  = sign(z)*(1.-gpp)/sh1;
     gpp/= 0.5*sh1*sh1*zd;
   } else {
-    register double x;
+     double x;
     x   = abs(z/zd);
     gpp = exp(-x);
     g   = zd*(gpp-1+x);
@@ -926,14 +926,14 @@ double DiskAnsatz::Residual(double r, double st, double ct) const
   if(hollow && r==0.) F=f=fp=fpp=0.;
   else if(eps) {
     if(hollow) {
-      register double rq=r*r,cr=cos(r/Rd),sr=sin(r/Rd);
+       double rq=r*r,cr=cos(r/Rd),sr=sin(r/Rd);
       F   = (R==0)? 0. : exp(-R0/R-R/Rd+eps*cos(R/Rd));
       f   = exp(-R0/r-r/Rd+eps*cr);
       fp  = R0/rq-(1.+eps*sr)/Rd;
       fpp = (fp*fp-2.*R0/(rq*r)-eps*cr/Rd2)*f;
       fp *= f;
     } else {
-      register double cr=cos(r/Rd),sr=sin(r/Rd);
+       double cr=cos(r/Rd),sr=sin(r/Rd);
       F   = exp(-R/Rd+eps*cos(R/Rd));
       f   = exp(-r/Rd+eps*cr);
       fp  = -(1.+eps*sr)/Rd;
@@ -942,7 +942,7 @@ double DiskAnsatz::Residual(double r, double st, double ct) const
     }
   } else {
     if(hollow) {
-      register double rq=r*r;
+       double rq=r*r;
       F   = (R==0)? 0. : exp(-R0/R-R/Rd);
       f   = exp(-R0/r-r/Rd);
       fp  = R0/rq-1./Rd;
@@ -965,21 +965,21 @@ double DiskAnsatz::operator() (double R, double z, double r, double* dP) const
     if(dP) dP[0]=dP[1]=0.;
     return 0.;
   }
-  register double g,f;
+   double g,f;
   if(dP) {
-    register double gp,fp;
+     double gp,fp;
     if(thin) {
       g  = abs(z);
       gp = sign(z);
     } else if(isothermal) {
-      register double x,ex,sh1;
+       double x,ex,sh1;
       x  = abs(z/zd);
       ex = exp(-x);
       sh1= 1.+ex;
       g  = 2*zd*(0.5*x+log(0.5*sh1));
       gp = sign(z)*(1.-ex)/sh1;
     } else {
-      register double x,ex;
+       double x,ex;
       x  = abs(z/zd);
       ex = exp(-x);
       g  = zd*(ex-1+x);
@@ -989,17 +989,17 @@ double DiskAnsatz::operator() (double R, double z, double r, double* dP) const
     if(hollow && r==0.) f=fp=0.;
     else if(eps) {
       if(hollow) {
-	register double rq=r*r,cr=cos(r/Rd),sr=sin(r/Rd);
+	 double rq=r*r,cr=cos(r/Rd),sr=sin(r/Rd);
 	f   = exp(-R0/r-r/Rd+eps*cr);
 	fp  = (R0/rq-(1.+eps*sr)/Rd)*f;
       } else {
-	register double cr=cos(r/Rd),sr=sin(r/Rd);
+	 double cr=cos(r/Rd),sr=sin(r/Rd);
 	f   = exp(-r/Rd+eps*cr);
 	fp  = -(1.+eps*sr)*f/Rd;
       }
     } else {
       if(hollow) {
-	register double rq=r*r;
+	 double rq=r*r;
 	f   = exp(-R0/r-r/Rd);
 	fp  = (R0/rq-1./Rd)*f;
       } else {
@@ -1013,13 +1013,13 @@ double DiskAnsatz::operator() (double R, double z, double r, double* dP) const
     if(thin) {
       g  =abs(z);
     } else if(isothermal) {
-      register double x,ex,sh1;
+       double x,ex,sh1;
       x  = abs(z/zd);
       ex = exp(-x);
       sh1= 1.+ex;
       g  = 2*zd*(0.5*x+log(0.5*sh1));
     } else {
-      register double x,ex;
+       double x,ex;
       x  = abs(z/zd);
       ex = exp(-x);
       g  = zd*(ex-1+x);
@@ -1041,14 +1041,14 @@ double DiskAnsatz::operator() (double R, double z, double r, double* dP) const
 double DiskAnsatz::Laplace(double R, double z) const
 {
   if(S0==0.) return 0;
-  register double r=hypot(R,z), g,gp,gpp, f,fp,fpp;
+   double r=hypot(R,z), g,gp,gpp, f,fp,fpp;
   // deal with the vertical part
   if(thin) {
     g  =abs(z);
     gp =sign(z);
     gpp=0.;
   } else if(isothermal) {
-    register double x,sh1;
+     double x,sh1;
     x   = abs(z/zd);
     gpp = exp(-x);
     sh1 = 1.+gpp;
@@ -1056,7 +1056,7 @@ double DiskAnsatz::Laplace(double R, double z) const
     gp  = sign(z)*(1.-gpp)/sh1;
     gpp/= 0.5*sh1*sh1*zd;
   } else {
-    register double x;
+     double x;
     x   = abs(z/zd);
     gpp = exp(-x);
     g   = zd*(gpp-1+x);
@@ -1067,14 +1067,14 @@ double DiskAnsatz::Laplace(double R, double z) const
   if(hollow && r==0.) f=fp=fpp=0.;
   else if(eps) {
     if(hollow) {
-      register double rq=r*r,cr=cos(r/Rd),sr=sin(r/Rd);
+       double rq=r*r,cr=cos(r/Rd),sr=sin(r/Rd);
 //       F   = (R==0)? 0. : exp(-R0/R-R/Rd+eps*cos(R/Rd));
       f   = exp(-R0/r-r/Rd+eps*cr);
       fp  = R0/rq-(1.+eps*sr)/Rd;
       fpp = (fp*fp-2.*R0/(rq*r)-eps*cr/Rd2)*f;
       fp *= f;
     } else {
-      register double cr=cos(r/Rd),sr=sin(r/Rd);
+       double cr=cos(r/Rd),sr=sin(r/Rd);
 //       F   = exp(-R/Rd+eps*cos(R/Rd));
       f   = exp(-r/Rd+eps*cr);
       fp  = -(1.+eps*sr)/Rd;
@@ -1083,7 +1083,7 @@ double DiskAnsatz::Laplace(double R, double z) const
     }
   } else {
     if(hollow) {
-      register double rq=r*r;
+       double rq=r*r;
 //       F   = (R==0)? 0. : exp(-R0/R-R/Rd);
       f   = exp(-R0/r-r/Rd);
       fp  = R0/rq-1./Rd;
@@ -1103,7 +1103,7 @@ Frequs DiskAnsatz::kapnuom(double R) const
 // returns dPhi/dR, d^2Phi/dR^2, d^2Phi/dz^2 at z=0
 {
   if(S0==0.) return Frequs(0.);
-  register double er, gpp;
+   double er, gpp;
   if(hollow) er = (R==0)? 0. : exp(-R0/R-R/Rd+eps*cos(R/Rd));
   else   er = exp(-R/Rd+eps*cos(R/Rd));
   if(thin) {                          // vertically thin disk
@@ -1190,7 +1190,7 @@ void SpheroidDensity::setup(const SphrPar& d)
 
 double SpheroidDensity::Density(double R, double z) const
 {
-  register double m = hypot(R,z*qi), m0=m*r0i, rho=rh0;
+   double m = hypot(R,z*qi), m0=m*r0i, rho=rh0;
   if(gam==0.5)   rho /= sqrt(m0);
   else if(gam==1.)    rho /= m0;
   else if(gam==2.)    rho /= m0*m0;
@@ -1363,8 +1363,8 @@ void Multipole::setup(double      ri,
   const    DBN    Zero=DBN(0.);
   const    double half=0.5, three=3., sixth=1./6.,
     dlr =(lRmax-lRmin)/double(K[0]-1);
-  register int    i,l,k,ll,lli1;
-  register double dx,dx2,xl_ll,xh_ll,risq,ril2,dP;
+   int    i,l,k,ll,lli1;
+   double dx,dx2,xl_ll,xh_ll,risq,ril2,dP;
   DBN    A[4],P2l,dP2l,EX;
   //
   // 0  check for inconsistencies in input
@@ -1603,7 +1603,7 @@ double Multipole::operator() (double r, double ct, double st, double* dP) const
     if(dP) dP[0] =-Phi;
   }
   if(dP) {
-    register double temp;
+     double temp;
     dP[0]/= r;
     dP[1]*=-st/r;
     temp  = ct*dP[0] - st*dP[1];
@@ -1717,8 +1717,8 @@ Frequs Multipole::kapnuom(double R) const
 
 double GalaxyPotential::operator() (double R, double z) const
 {
-  register double r  =hypot(R,z), pot=M(r,z/r,R/r);
-  for(register DiskAnsatz *p=D; p<Dup; p++) pot+= (*p)(R,z,r);
+   double r  =hypot(R,z), pot=M(r,z/r,R/r);
+  for( DiskAnsatz *p=D; p<Dup; p++) pot+= (*p)(R,z,r);
   return pot;
 }
 
@@ -1726,9 +1726,9 @@ double GalaxyPotential::operator() (double R, double z,
                                     double&dR, double&dz) const
 {
   double d[2];
-  register double r  =hypot(R,z), pot=M(r,z/r,R/r,d);
+   double r  =hypot(R,z), pot=M(r,z/r,R/r,d);
   dR = d[0]; dz = d[1];
-  for(register DiskAnsatz *p=D; p<Dup; p++) {
+  for( DiskAnsatz *p=D; p<Dup; p++) {
     pot += (*p)(R,z,r,d);
     dR  += d[0];
     dz  += d[1];
@@ -1747,8 +1747,8 @@ void GalaxyPotential::OortConstants(double R, double &A, double &B) const
 
 double GalaxyPotential::Laplace(double R, double z) const
 {
-  register double r=hypot(R,z), L=M.Laplace(r,z/r);
-  register DiskAnsatz *p=D;
+   double r=hypot(R,z), L=M.Laplace(r,z/r);
+   DiskAnsatz *p=D;
   for(; p<Dup; p++) L += p->Laplace(R,z);
   return L;
 }
@@ -1756,7 +1756,7 @@ double GalaxyPotential::Laplace(double R, double z) const
 Frequs GalaxyPotential::KapNuOm  (double R) const
 {
   Frequs Om = M.kapnuom(R);
-  for(register DiskAnsatz *p=D; p<Dup; p++) Om += p->kapnuom(R);
+  for( DiskAnsatz *p=D; p<Dup; p++) Om += p->kapnuom(R);
   Om[2]/= R;
   Om[0]+= 3*Om(2);
   Om.apply(&sqrt);

--- a/usr/dehnen/falcON/inc/acc/GalPot_pre.h
+++ b/usr/dehnen/falcON/inc/acc/GalPot_pre.h
@@ -230,7 +230,7 @@ namespace GalPot {                               // v0.4
     SphrPar Parameter        (int i) const { return (S+i)->parameter(); }
   };
   inline bool Spheroids::massive() const {
-    for(register SpheroidDensity *p=S; p!=Sup; ++p)
+    for( SpheroidDensity *p=S; p!=Sup; ++p)
       if(p->scale_density()) return true;
     return false;
   }

--- a/usr/dehnen/falcON/inc/acc/center.h
+++ b/usr/dehnen/falcON/inc/acc/center.h
@@ -73,13 +73,13 @@ namespace {
 	return NDIM == 2? 0.25*Pi : 4*Pi / 19.6875;
       }
       static void   diff(double const&m, double const&xq, double D[3]) {
-	register double t = 1.-xq, d=m*t, d2=d*t, d3=d2*t;
+	 double t = 1.-xq, d=m*t, d2=d*t, d3=d2*t;
 	D[2] = 24*d;
 	D[1] =-6*d2;
 	D[0] = d3;
       }
       static void   diff1(double const&m, double const&xq, double D[2]) {
-	register double t = 1.-xq, d2=m*t*t, d3=d2*t;
+	 double t = 1.-xq, d2=m*t*t, d3=d2*t;
 	D[1] =-6*d2;
 	D[0] = d3;
       }

--- a/usr/dehnen/falcON/inc/acc/timer.h
+++ b/usr/dehnen/falcON/inc/acc/timer.h
@@ -111,7 +111,7 @@ namespace {
       if(t <= t0) return 0.;
       if(t >= t1) return 1.;
       const double a0=0.1875, a1=0.625, a2=0.9375;
-      register double
+       double
 	xi  = twice(t-t0)*itau-1,
 	xq  = xi*xi;
       xi *= ((a0*xq - a1)*xq + a2);

--- a/usr/dehnen/falcON/inc/body.h
+++ b/usr/dehnen/falcON/inc/body.h
@@ -1626,7 +1626,7 @@ namespace falcON {
     /// that two or more manipulators may communicate data, for instance one
     /// manipulator determines the centre with respect to which another
     /// manipulator analyses the snapshot. For this purpose, the first
-    /// manipulator registers a pointer to the centre position with the pointer
+    /// manipulator s a pointer to the centre position with the pointer
     /// bank under a handle, say \c "xcen", using members add_pointer() or
     /// set_pointer(). Any other manipulator may access that pointer with the
     /// same handle using the member pointer() or get_pointer().\n

--- a/usr/dehnen/falcON/inc/main.h
+++ b/usr/dehnen/falcON/inc/main.h
@@ -330,7 +330,7 @@ namespace falcON {
   //                                                                          //
   //////////////////////////////////////////////////////////////////////////////
   inline void check_sufficient(fieldset const&read, fieldset const&need)
-    throw(falcON::exception) {
+    noexcept(false) {
     if(! read.contain(need)) {
       fieldset::wlist wneed(&need);
       fieldset::wlist wread(&read);

--- a/usr/dehnen/falcON/inc/public/basic.h
+++ b/usr/dehnen/falcON/inc/public/basic.h
@@ -84,7 +84,7 @@ namespace falcON {
   //----------------------------------------------------------------------------
 #ifdef WDutils_EXCEPTIONS
 #  define falcON_EXCEPTIONS
-#  define falcON_THROWING      throw(falcON::exception)
+#  define falcON_THROWING      noexcept(false)
 #  define falcON_THROWER       throw WDutils::Thrower
 #  define falcON_THROWN        throw falcON::exception
 #  define falcON_RETHROW(E)    WDutils_RETHROW(E)

--- a/usr/dehnen/falcON/inc/public/bodyfunc.h
+++ b/usr/dehnen/falcON/inc/public/bodyfunc.h
@@ -65,13 +65,15 @@ namespace falcON {
     typedef T(*const bf_pter)(body const&, double, const real*);
     static T func(void(*const f)(body const&, double, const real*),
 		  body const&b, double t, const real*p) {
-      return f? (*(bf_pter)(f))(b,t,p) : bf_type_base<T>::default_value();
+      if (f) { f(b,t,p); }
+      return bf_type_base<T>::default_value();
     }
     //--------------------------------------------------------------------------
     typedef T(*const Bf_pter)(bodies const&, double, const real*);
     static T func(void(*const f)(bodies const&, double, const real*),
 		  bodies const&b, double t, const real*p) {
-      return f? (*(Bf_pter)(f))(b,t,p) : bf_type_base<T>::default_value();
+      if (f) { f(b,t,p); }
+      return bf_type_base<T>::default_value();
     }
   };
   // ///////////////////////////////////////////////////////////////////////////

--- a/usr/dehnen/falcON/inc/public/bodyfunc.h
+++ b/usr/dehnen/falcON/inc/public/bodyfunc.h
@@ -113,7 +113,7 @@ namespace falcON {
     static bool print_db(std::ostream&out);
     /// ctor from expression (see man pages)
     /// \param[in] expr  suitable expression (see man pages)
-    explicit bodyfunc(const char*expr) throw(falcON::exception);
+    explicit bodyfunc(const char*expr) noexcept(false);
     /// copy ctor
     bodyfunc(bodyfunc const&bf)
       : FUNC(bf.FUNC), TYPE(bf.TYPE), NPAR(bf.NPAR), NEED(bf.NEED), EXPR(0)
@@ -194,27 +194,27 @@ namespace falcON {
   class Bodyfunc : protected bodyfunc {
     real P[MAXPAR];
     char*PARS;
-    void getpars(const real*, int) throw(falcON::exception);
+    void getpars(const real*, int) noexcept(false);
   public:
     /// construction from bodyfunc expression (can be empty)
     /// \param[in] expr_ bodyfunc (5falcON) expression --- or NULL
     /// \param[in] pars_ comma separated list of parameters
     Bodyfunc(const char*expr_, const char*pars_)
-      throw(falcON::exception);
+      noexcept(false);
     /// construction from bodyfunc expression (can be empty)
     /// \param[in] expr_  bodyfunc (5falcON) expression --- or NULL
     /// \param[in] pars_  array with parameters 
     /// \param[in] npar_  number of parameters
     /// \note there must be enough parameters given
     Bodyfunc(const char*expr_, const real*pars_, int npar_)
-      throw(falcON::exception)
+      noexcept(false)
       : bodyfunc(expr_), PARS(0) { getpars(pars_,npar_); }
     /// construction from bodyfunc and parameters
     /// \param[in] bf    bodyfunc
     /// \param[in] pars  array with parameters, if any 
     /// \note the number of parameter is expected to match bf.npar()
     Bodyfunc(bodyfunc const&bf, const real*pars)
-      throw(falcON::exception)
+      noexcept(false)
       : bodyfunc(bf), PARS(0) { getpars(pars,NPAR); }
     /// ctor from function and parameters
     /// \param[in] func_  pter to function to be used
@@ -230,7 +230,7 @@ namespace falcON {
     template<typename Type>
     Bodyfunc(Type(*func_)(body const&, double, const real*),
 	     int npar_, fieldset need_, const char*expr_, const real*pars_)
-      throw(falcON::exception)
+      noexcept(false)
       : bodyfunc(func_,npar_,need_,expr_), PARS(0) { getpars(pars_,npar_); }
     /// dtor: delete data
     ~Bodyfunc() { if(PARS) falcON_DEL_A(PARS); PARS=0; }
@@ -281,14 +281,14 @@ namespace falcON {
   //
   // ///////////////////////////////////////////////////////////////////////////
   template<typename T> class BodyFunc : private Bodyfunc {
-    void checktype() const throw(falcON::exception);
+    void checktype() const noexcept(false);
   public:
     /// construction from bodyfunc expression (can be empty)
     /// \param[in] expr_  body_func (5falcON) expression --- or NULL
     /// \param[in] pars_  comma separated list of parameters
     /// \note the bodyfunc expression must return the type T
     BodyFunc(const char*expr_, const char*pars_)
-      throw(falcON::exception)
+      noexcept(false)
       : Bodyfunc(expr_,pars_) { checktype(); }
     /// construction from bodyfunc expression (can be empty)
     /// \param[in] expr_  body_func (5falcON) expression --- or NULL
@@ -297,14 +297,14 @@ namespace falcON {
     /// \note there must be enough parameters given
     /// \note the bodyfunc expression must return the type T
     BodyFunc(const char*expr_, const real*pars_, int npar_)
-      throw(falcON::exception)
+      noexcept(false)
       : Bodyfunc(expr_,pars_,npar_) { checktype(); }
     /// construction from bodyfunc and parameters
     /// \param[in] bf    bodyfunc
     /// \param[in] pars  array with parameters, if any 
     /// \note the number of parameter is expected to match bf.npar()
     BodyFunc(bodyfunc const&bf, const real*pars)
-      throw(falcON::exception)
+      noexcept(false)
       : Bodyfunc(bf,pars) { checktype(); }
     /// ctor from function and parameters
     /// \param[in] func_  pter to function to be used
@@ -320,7 +320,7 @@ namespace falcON {
     template<typename Type>
     BodyFunc(Type(*func_)(body const&, double, const real*),
 	     int npar_, fieldset need_, const char*expr_, const real*pars_)
-      throw(falcON::exception)
+      noexcept(false)
       : Bodyfunc(func_,npar_,need_,expr_,pars_) { checktype(); }
     /// return number of parameters used
     using Bodyfunc::npar;
@@ -395,7 +395,7 @@ namespace falcON {
     /// \param[in] f pter to Bodyfunc
     /// \param[in] t time to use
     BodyProp(const Bodyfunc*f, double t) 
-      throw(falcON::exception) : F(f), T(t)
+      noexcept(false) : F(f), T(t)
     {
       if(!F->is_type<functype>())
 	throw falcON::exception("BodyProp<%c>: type mismatch: "
@@ -451,7 +451,7 @@ namespace falcON {
     /// \param[in] pars comma separated list of parameters
     /// \note the bodyfunc expression must return the type T
     BodyFilter(const char*expr, const char*pars)
-      throw(falcON::exception);
+      noexcept(false);
     /// construction from bodyfunc expression (can be empty)
     /// \param[in] expr body_func (5falcON) expression --- or NULL
     /// \param[in] pars array with parameters
@@ -459,7 +459,7 @@ namespace falcON {
     /// \note there must be enough parameters given
     /// \note the bodyfunc expression must return the type T
     BodyFilter(const char*expr, const real*pars, int npar)
-      throw(falcON::exception);
+      noexcept(false);
     /// set the time for future function calls
     /// \param[in] t (input) simulation time
     void set_time(double t)
@@ -526,7 +526,7 @@ namespace falcON {
     /// \param  out  ostream to print to
     static bool print_db(std::ostream&out);
     /// construction from bodyfunc expression
-    explicit bodiesfunc(const char*) throw(falcON::exception);
+    explicit bodiesfunc(const char*) noexcept(false);
     /// return type: 'b', 'i', 'r', 'v' for bool, int, real, vect
     char const&type() const { return TYPE; }
     /// check return type

--- a/usr/dehnen/falcON/inc/public/bodyfuncdefs.h
+++ b/usr/dehnen/falcON/inc/public/bodyfuncdefs.h
@@ -123,17 +123,17 @@ namespace {
   inline real mtot(body const&b) { return mtot(*(b.my_bodies())); }
 
   inline real vrad(body const&b) {
-    register real r = abs(pos(b));
+     real r = abs(pos(b));
     if(r==zero) return zero;
     return (pos(b)*vel(b))/r;
   }
   inline real vtan(body const&b) {
-    register real r = abs(pos(b));
+     real r = abs(pos(b));
     if(r==zero) return zero;
     return abs(pos(b)^vel(b))/r;
   }
   inline real vphi(body const&b) {
-    register real R = sqrt(square(pos(b)[0])+square(pos(b)[1]));
+     real R = sqrt(square(pos(b)[0])+square(pos(b)[1]));
     if(R==zero) return zero;
     return (pos(b)[0]*vel(b)[1] - pos(b)[1]*vel(b)[0])/R;
   }

--- a/usr/dehnen/falcON/inc/public/gamma.h
+++ b/usr/dehnen/falcON/inc/public/gamma.h
@@ -336,7 +336,7 @@ namespace falcON {
   { 
     if(p==0.) return 1.;
     if(g==2.) return exp(-p);
-    register double pg2=p*g2;
+     double pg2=p*g2;
     if(g2>0. && pg2>1.) falcON_Error("DehnenModel: psi out of range");
     return pow(1.-pg2, ig2);
   }
@@ -379,7 +379,7 @@ namespace falcON {
       dP = - square(1-y)/y;
       return -std::log(y);
     } else {
-      register double t = pow(y,g1);
+       double t = pow(y,g1);
       dP = - square(1-y)*t;
       return ig2 * (1.-y*t);
     }
@@ -400,7 +400,7 @@ namespace falcON {
       d2P = - square(d1P);
       return -std::log(y);
     } else {
-      register double t = pow(y,-g), y1=1-y, u=y1*y1*t;
+       double t = pow(y,-g), y1=1-y, u=y1*y1*t;
       d1P = - u * y;
       d2P =   u * y1 * (g3*y-g1);
       return ig2 * (1.-y*y*t);
@@ -607,7 +607,7 @@ namespace falcON {
   //----------------------------------------------------------------------------
   inline double DehnenModel::XofELC(double e, double l, double cet) const
   {
-    register double ye = Yc<ec>(e);
+     double ye = Yc<ec>(e);
     return Xc<yc>(ye) * pow(1 + cet*sqrt(1-l*l/Lq<yc>(ye)),0.5*Gm<yc>(ye));
   }
   //----------------------------------------------------------------------------
@@ -716,7 +716,7 @@ namespace falcON {
   template<> inline
   double ScaledDehnenModel::Ps1<DehnenModel::ym>(double y, double&dP) const
   {
-    register double _ps = sE*DehnenModel::Ps1<ym>(y,dP);
+     double _ps = sE*DehnenModel::Ps1<ym>(y,dP);
     dP *= sA;
     return _ps;
   }
@@ -731,7 +731,7 @@ namespace falcON {
 						 double&d1P,
 						 double&d2P) const
   {
-    register double _ps = sE*DehnenModel::Ps2<ym>(y,d1P,d2P);
+     double _ps = sE*DehnenModel::Ps2<ym>(y,d1P,d2P);
     d1P *= sA;
     d2P *= sS;
     return _ps;
@@ -756,7 +756,7 @@ namespace falcON {
   template<> inline
   double ScaledDehnenModel::Rh1<DehnenModel::ym>(double y, double&dR) const
   {
-    register double rh = sD*DehnenModel::Rh1<ym>(y,dR);
+     double rh = sD*DehnenModel::Rh1<ym>(y,dR);
     dR *= sB;
     return rh;
   }
@@ -771,7 +771,7 @@ namespace falcON {
 						 double&d1R,
 						 double&d2R) const
   {
-    register double rh = sD*DehnenModel::Rh2<ym>(y,d1R,d2R);
+     double rh = sD*DehnenModel::Rh2<ym>(y,d1R,d2R);
     d1R *= sB;
     d2R *= sC;
     return rh;
@@ -1032,7 +1032,7 @@ namespace falcON {
   // provide the abstract functions and more                                    
   //----------------------------------------------------------------------------
   inline double DehnenModelSampler::DF (double e) const {
-    register double ye = ScaledDehnenModel::Y<DehnenModel::ps>(e);
+     double ye = ScaledDehnenModel::Y<DehnenModel::ps>(e);
     if(ye >= 1.   ) return 0.;
     if(ye < y[0]  ) return exp(f[0]   + fi*log(ye/y[0]) );
     if(ye > y[n-1]) return exp(f[n-1] + fo*log((1-ye)/(1-y[n-1])) );

--- a/usr/dehnen/falcON/inc/public/gravity.h
+++ b/usr/dehnen/falcON/inc/public/gravity.h
@@ -246,7 +246,7 @@ namespace falcON {
       //------------------------------------------------------------------------
       void normalize_grav () {                     // acc,pot     /= mass       
 	if(mass()>zero) {
-	  register real im = one/mass();
+	   real im = one/mass();
 	  pot() *= im;
 	  acc() *= im;
 	}

--- a/usr/dehnen/falcON/inc/public/gravity.h
+++ b/usr/dehnen/falcON/inc/public/gravity.h
@@ -642,10 +642,10 @@ namespace falcON {
     return mass(C)!=zero;
   }
   inline real xmin(const GravEstimator::Cell*C) {
-    return cofm(C).min() - rmax(C);
+    return min(cofm(C)) - rmax(C);
   }
   inline real xmax(const GravEstimator::Cell*C) {
-    return cofm(C).max() + rmax(C);
+    return max(cofm(C)) + rmax(C);
   }
   // ///////////////////////////////////////////////////////////////////////////
   //                                                                          //

--- a/usr/dehnen/falcON/inc/public/kernel.h
+++ b/usr/dehnen/falcON/inc/public/kernel.h
@@ -187,7 +187,7 @@ namespace falcON {
     //--------------------------------------------------------------------------
     void give_coeffs(grav::cell_pter const&C) const {
       if(COEFF_POOL && !hasCoeffs(C)) {
-	register grav::Cset*X = static_cast<grav::Cset*>(COEFF_POOL->alloc());
+	 grav::Cset*X = static_cast<grav::Cset*>(COEFF_POOL->alloc());
 	X->set_zero();
 	C->setCoeffs(X);
 	++NC;

--- a/usr/dehnen/falcON/inc/public/nbody.h
+++ b/usr/dehnen/falcON/inc/public/nbody.h
@@ -270,7 +270,7 @@ namespace falcON {
     /// \param CPU (output) time since \c c0 is added to CPU in seconds
     static void record_cpu(std::clock_t& c0, double& CPU)
     {
-      register std::clock_t c1 = std::clock();
+       std::clock_t c1 = std::clock();
       CPU += (c1-c0)/real(CLOCKS_PER_SEC);
       c0   = c1;
     }
@@ -302,7 +302,7 @@ namespace falcON {
   protected:
     /// record a CPU timing and cumulative CPU time after a full step
     void add_to_cpu_step() const {
-      register std::clock_t c1 = clock();
+       std::clock_t c1 = clock();
       CPU_STEP    += (c1-C_OLD)/real(CLOCKS_PER_SEC);
       CPU_TOTAL   += (c1-C_OLD)/real(CLOCKS_PER_SEC);
       C_OLD        = c1;

--- a/usr/dehnen/falcON/inc/public/nbody.h
+++ b/usr/dehnen/falcON/inc/public/nbody.h
@@ -128,14 +128,14 @@ namespace falcON {
     /// tensor computation as outer product or two vectors                      
     static void AddTensor(double t[Ndim][Ndim], vect_d const&x, vect const&y) {
       meta::_addt<Ndim-1>::a(t,
-			      static_cast<const double*> (x),
-			      static_cast<const real  *> (y));
+			      x.data(),
+			      y.data());
     }
     /// tensor computation as outer product or two vectors                      
     static void AddTensor(float t[Ndim][Ndim], vect_f const&x, vect const&y) {
       meta::_addt<Ndim-1>::a(t,
-			      static_cast<const float*> (x),
-			      static_cast<const real *> (y));
+			      x.data(),
+			      y.data());
     }
     /// asymmetric angular momentum tensor (funny idea, not mine anyway)        
     static real as_angmom     (vect const&L,

--- a/usr/dehnen/falcON/inc/public/profile.h
+++ b/usr/dehnen/falcON/inc/public/profile.h
@@ -151,7 +151,7 @@ namespace falcON {
     /// direction of rotation axis
     vect_d drot(int i) const { 
       vect_d t(vp[i]);
-      return t.normalize();
+      return t.normalise();
     }
     /// direction of major axis
     const vect_d&major_axis(int i) const { return xa[i]; }

--- a/usr/dehnen/falcON/inc/public/simd.h
+++ b/usr/dehnen/falcON/inc/public/simd.h
@@ -110,7 +110,7 @@ namespace falcON {
     fvec4& operator*=(float t)            { W*=t;    X*=t;    Y*=t;    Z*=t;
                                             return *this; }
     //--------------------------------------------------------------------------
-    fvec4& operator/=(float t)            { register float x=1./t;
+    fvec4& operator/=(float t)            {  float x=1./t;
                                             return operator*=(x);  }
     //--------------------------------------------------------------------------
     fvec4& ass_sum (fvec4 const&v, fvec4 const&w) {

--- a/usr/dehnen/falcON/inc/public/tensor.h
+++ b/usr/dehnen/falcON/inc/public/tensor.h
@@ -149,6 +149,8 @@ namespace falcON {
     typedef const T         cT;                    // const tensor
     typedef meta::taux<X,KK> M;                    // meta looping (l,m) to K
     // static methods (type conversions to X* and const X*)
+    static X*      pX(falcONVec<3,X>      &x) { return x.data(); }
+    static const X*pX(falcONVec<3,X> const&x) { return x.data(); }
     template<class A>
     static X*      pX(A      &x) { return static_cast<      X*>(x); }
     template<class A>
@@ -293,6 +295,8 @@ namespace falcON {
     typedef const T         cT;                    // const tensor
     typedef meta::taux<X,5>  M;                    // meta looping (l,m) to K
     // static methods (type conversions to X* and const X*)
+    static X*      pX(falcONVec<3,X>      &x) { return x.data(); }
+    static const X*pX(falcONVec<3,X> const&x) { return x.data(); }
     template<class A>
     static X*      pX(A      &x) { return static_cast<      X*>(x); }
     template<class A>

--- a/usr/dehnen/falcON/inc/public/tensor_set.cc
+++ b/usr/dehnen/falcON/inc/public/tensor_set.cc
@@ -604,14 +604,14 @@ namespace falcON {
   //
   tNX inline void
   shift_by(symset3D<N,X>&C, falcONVec<3,X>&x)
-  { meta3D::__shift<N,N,0>::by(static_cast<X*>(C), static_cast<X*>(x)); }
+  { meta3D::__shift<N,N,0>::by(static_cast<X*>(C), x.data()); }
   //
   tNX inline void
   eval_expn(symset3D<1,X>&G, symset3D<N,X> const&C, falcONVec<3,X> const&x)
   {
     meta3D::__shift<N,N,0>::at(static_cast<X*>(G),
 			       static_cast<const X*>(C),
-			       static_cast<const X*>(x));
+			       x.data());
   }
   //
   namespace meta3D {
@@ -891,11 +891,11 @@ namespace falcON {
 #else
   tNX inline void
   set_dPhi(symset3D<N,X>&C, falcONVec<3,X> const&v, X const D[N+1])
-  { meta3D::__grav<N>::ass(C,static_cast<const X*>(v),D); }
+  { meta3D::__grav<N>::ass(C,v.data(),D); }
   //
   tNX inline void
   add_dPhi(symset3D<N,X>&C, falcONVec<3,X> const&v, X const D[N+1])
-  { meta3D::__grav<N>::add(C,static_cast<const X*>(v),D); }
+  { meta3D::__grav<N>::add(C,v.data(),D); }
 #endif
   //
   namespace meta3D {

--- a/usr/dehnen/falcON/inc/public/tensor_set.cc
+++ b/usr/dehnen/falcON/inc/public/tensor_set.cc
@@ -265,7 +265,7 @@ namespace falcON {
     tm<int N> struct po<2,N> {                     // a+=b=m*(v op v) & cont
       tX sv ad(X*a, X*b, cX*v, cX&m)
       {
-	register X tmp  = m * v[0];
+	X tmp  = m * v[0];
 	a[0] += b[0] = v[0] * tmp;
 	a[1] += b[1] = v[1] * tmp;
 	a[2] += b[2] = v[2] * tmp;
@@ -279,7 +279,7 @@ namespace falcON {
     tm<> struct po<2,2> {                          // a+=m*(v op v)  DONE
       tX sv ad(X*a, cX*v, cX&m)
       {
-	register X tmp  = m * v[0];
+	X tmp  = m * v[0];
 	a[0] += v[0] * tmp;
 	a[1] += v[1] * tmp;
 	a[2] += v[2] * tmp;
@@ -426,7 +426,7 @@ namespace falcON {
     tm<int N> struct __norm<2,N> {
       tX sv job(poles3D<N,X>&M, cX&x)
       {
-	register X ix = X(1)/x;
+	X ix = X(1)/x;
 	M.template pole<2>() *= (ix*iF[2]);
 	__norm<3,N>::job(M,ix);
       }
@@ -743,7 +743,7 @@ namespace falcON {
       tX sv __ass(X*a, const X*v, D_ARG)
       {
 	a[ 0] = __D(0,J);
-	register X t =-__D(1,J);
+	X t =-__D(1,J);
 	a[ 1] = v[0]*t;
 	a[ 2] = v[1]*t;
 	a[ 3] = v[2]*t;
@@ -753,7 +753,7 @@ namespace falcON {
       tX sv __add(X*a, const X*v, D_ARG)
       {
 	a[ 0]+= __D(0,J);
-	register X t =-__D(1,J);
+	X t =-__D(1,J);
 	a[ 1]+= v[0]*t;
 	a[ 2]+= v[1]*t;
 	a[ 3]+= v[2]*t;
@@ -766,7 +766,7 @@ namespace falcON {
       tX sv __ass(X*a, const X*v, D_ARG)
       {
 	a[ 0] = __D(0,J);
-	register X t =-__D(1,J);
+	X t =-__D(1,J);
 	a[ 1] = v[0]*t;
 	a[ 2] = v[1]*t;
 	a[ 3] = v[2]*t;
@@ -785,7 +785,7 @@ namespace falcON {
       tX sv __add(X*a, const X*v, D_ARG)
       {
 	a[ 0]+= __D(0,J);
-	register X t =-__D(1,J);
+	X t =-__D(1,J);
 	a[ 1]+= v[0]*t;
 	a[ 2]+= v[1]*t;
 	a[ 3]+= v[2]*t;
@@ -807,7 +807,7 @@ namespace falcON {
       tX sv __ass(X*a, const X*v, D_ARG)
       {
 	a[ 0] = __D(0,J);
-	register X t =-__D(1,J);
+	X t =-__D(1,J);
 	a[ 1] = v[0]*t;
 	a[ 2] = v[1]*t;
 	a[ 3] = v[2]*t;
@@ -820,7 +820,7 @@ namespace falcON {
 	a[ 8] = t*v[2];
 	t     = __D(2,J)*v[2];
 	a[ 9] = t*v[2] - __D(1,J);
-	register X D2_3 = times<3>(__D(2,J));
+	X D2_3 = times<3>(__D(2,J));
 	t     = __D(3,J)*v[0]*v[0];
 	a[10] = (D2_3-t)*v[0];
 	a[11] = (__D(2,J)-t)*v[1];
@@ -840,7 +840,7 @@ namespace falcON {
       tX sv __add(X*a, const X*v, D_ARG)
       {
 	a[ 0]+= __D(0,J);
-	register X t = __D(1,J);
+	X t = __D(1,J);
 	a[ 1]-= v[0]*t;
 	a[ 2]-= v[1]*t;
 	a[ 3]-= v[2]*t;
@@ -853,7 +853,7 @@ namespace falcON {
 	a[ 8]+= t*v[2];
 	t     = __D(2,J)*v[2];
 	a[ 9]+= t*v[2] - __D(1,J);
-	register X D2_3 = times<3>(__D(2,J));
+	X D2_3 = times<3>(__D(2,J));
 	t     = __D(3,J)*v[0]*v[0];
 	a[10]+= (D2_3-t)*v[0];
 	a[11]+= (__D(2,J)-t)*v[1];

--- a/usr/dehnen/falcON/inc/public/tensor_set.h
+++ b/usr/dehnen/falcON/inc/public/tensor_set.h
@@ -53,10 +53,12 @@ namespace falcON {
     typedef meta::taux<X,NDAT-1>  L;               // meta looping (k,l,m)
     typedef falcONVec<3,X>        V;               // vector
     // static methods (type conversions to X* and const X*)
+    static X*      pX(falcONVec<3,X>      &x) { return x.data(); }
+    static const X*pX(falcONVec<3,X> const&x) { return x.data(); }
     template<class A>
-    static X*      pX(A      &x) { return static_cast<      X*>(x); }
+    static X*      pX(A      &x) { return (      X*)(x); }
     template<class A>
-    static const X*pX(A const&x) { return static_cast<const X*>(x); }
+    static const X*pX(A const&x) { return (const X*)(x); }
     // datum
     X a[NDAT];
   public:
@@ -123,10 +125,12 @@ namespace falcON {
     typedef meta::taux<X,NDAT-1>  L;               // meta looping (k,l,m)
     typedef falcONVec<3,X>        V;               // vector
     // static methods (type conversions to X* and const X*)
+    static       X*pX(falcONVec<3,X>      &x) { return x.data(); }
+    static const X*pX(falcONVec<3,X> const&x) { return x.data(); }
     template<class A>
     static       X*pX(A      &x) { return static_cast<      X*>(x); }
     template<class A>
-    static const X*pX(A const&x) { return static_cast<const X*>(x); }
+    static const X*pX(A const&x) { return (const X*)(x); }
     // datum
     X a[NDAT];
   public:

--- a/usr/dehnen/falcON/inc/public/tensor_set.h
+++ b/usr/dehnen/falcON/inc/public/tensor_set.h
@@ -137,6 +137,7 @@ namespace falcON {
     // construction
     symset3D()                   {}
     explicit symset3D(X const&x) { L::s_as(a,x); }
+    symset3D(C const&c) { L::v_as(a, c.a); }
     // element access
     template<int K> typename meta3D::ONE3D<K,X>::Tensor
     const&tensor () const { return meta3D::ONE3D<K,X>::tens(a); }

--- a/usr/dehnen/falcON/inc/public/tree.h
+++ b/usr/dehnen/falcON/inc/public/tree.h
@@ -196,7 +196,7 @@ namespace falcON {
       void dump(std::ostream&o) const {
 	o<<' '<<std::setw(3) << FLAGS
 	 <<' '<<std::setw(2) << LINK.no()<<' '<<std::setw(6)<<LINK.in();
-	for(register int d=0; d!=Ndim; ++d)
+	for(int d=0; d!=Ndim; ++d)
 	  o<<' '<<std::setw(9)<<std::setprecision(4)<<POS[d];
       }
     }; // class Leaf
@@ -349,7 +349,7 @@ namespace falcON {
 	 <<' '<<std::setw(5)<<FCLEAF
 	 <<' '<<std::setw(5)<<NLEAFS
 	 <<' '<<std::setw(6)<<NUMBER;
-	for(register int d=0; d!=Ndim; ++d)
+	for(int d=0; d!=Ndim; ++d)
 	  o<<' '<<std::setw(8)<<std::setprecision(4)<<CENTRE[d];
       }
       //------------------------------------------------------------------------
@@ -872,7 +872,7 @@ namespace falcON {
   void OctTree::dump_leafs(std::ostream&o) const {
     LEAF_TYPE::dump_head(o);
     o <<'\n';
-    for(register leaf_iterator Li=begin_leafs(); Li!=end_leafs(); ++Li) {
+    for(leaf_iterator Li=begin_leafs(); Li!=end_leafs(); ++Li) {
       o <<' '<< std::setw(5)<<index(Li);
       static_cast<LEAF_TYPE*>(Li)->dump(o);
       o <<'\n';

--- a/usr/dehnen/falcON/inc/public/tree.h
+++ b/usr/dehnen/falcON/inc/public/tree.h
@@ -552,6 +552,13 @@ namespace falcON {
 	C = static_cast<CELL*>(I.c_pter());
 	return *this;
       }
+      CellIter& operator=(CellIter const&I) {
+        if (this != &I) {
+          T = I.T;
+          C = I.C;
+        }
+        return *this;
+      }
       //------------------------------------------------------------------------
       /// \name forward iteration
       //@{

--- a/usr/dehnen/falcON/inc/public/types.h
+++ b/usr/dehnen/falcON/inc/public/types.h
@@ -139,6 +139,11 @@ namespace WDutils {				\
 #  include <public/tensor.h>
 #endif
 
+# ifndef WDutils_included_vector_h
+#  include <utils/vector.h>
+# endif
+# define falcONVec vector
+
 namespace falcON {
   typedef falcONVec<Ndim,real  > vect;          ///< a vector of 3 reals
   typedef falcONVec<Ndim,float>  vect_f;        ///< a vector of 3 floats

--- a/usr/dehnen/falcON/makepub
+++ b/usr/dehnen/falcON/makepub
@@ -5,6 +5,9 @@
 #
 ################################################################################
 
+# detect OSTYPE (Linux or Darwin) 
+OSTYPE := $(shell uname)
+
 # -----------
 # directories
 # -----------
@@ -320,8 +323,12 @@ $(ACC)Point.so:			$(SACC)Point.cc $(ACCT) $(defacc_h) $(makefiles)
 				$(MAKE_ACC)
 $(ACC)PotExp.so:                $(SACC)PotExp.cc $(ACCT) $(PotExp_cc) $(defacc_h) $(makefiles)
 				$(MAKE_ACC) -I$(SRC) $(NBDYFLAGS)
+ifneq ($(OSTYPE),Darwin)
 $(ACC)Shrink.so:		$(SACC)Shrink.cc $(ACCT) $(timer_h) $(defacc_h) $(makefiles)
 				$(MAKE_ACC)
+else
+$(ACC)Shrink.so:		
+endif
 $(ACC)SoftKernel.so:		$(SACC)SoftKernel.cc $(ACCT) $(defacc_h) $(makefiles)
 				$(MAKE_ACC) $(NBDYFLAGS)
 $(ACC)GasPotential.so:		$(SACC)GasPotential.cc $(ACCT) $(defacc_h) $(makefiles)

--- a/usr/dehnen/falcON/src/public/acc/Combined.cc
+++ b/usr/dehnen/falcON/src/public/acc/Combined.cc
@@ -91,7 +91,7 @@ namespace {
 	}
 	++l;
       }
-      error("Combined: line longer than expected\n");
+      error((char *) "Combined: line longer than expected\n");
     }
     //--------------------------------------------------------------------------
     static void read_line(std::istream& from, char*line, int const&n)
@@ -196,7 +196,7 @@ namespace {
 	     const char  *file) : NEEDM(0), NEEDV(0)
     {
       if(npar < 4 || file==0)
-	warning("Combined: recognizes 3 parameters and requires a data file.\n"
+	warning((char*)"Combined: recognizes 3 parameters and requires a data file.\n"
 		"parameters:\n"
 		"  par[0] = controlling growth factor, see below         [9]\n"
 		"  par[1] = t0: start time for growth                    [0]\n"
@@ -219,7 +219,7 @@ namespace {
 		timer::describe(timer::exponential),
 		timer::describe(timer::constant),
 		NMAX);
-      if(file == 0) error("Combined: not data file given");
+      if(file == 0) error((char*)"Combined: not data file given");
       // initialize timer
       timer::index
 	timin = (timer::index)(npar>0? int(pars[0]) : 9);
@@ -228,7 +228,7 @@ namespace {
 	_tau   = npar>2? pars[2] : 1.,
 	_t1    = npar>3? pars[3] : 10.;
       timer::init(timin,_t0,_tau,_t1);
-      if(npar>4) warning("Combined: skipped parameters beyond 4");
+      if(npar>4) warning((char*)"Combined: skipped parameters beyond 4");
       nemo_dprintf (1,
 		    "initializing Combined\n"
 		    " parameters : timer::index  = %f -> %s\n"
@@ -240,14 +240,14 @@ namespace {
       const int size=200;
       std::ifstream inpt(file);
       if(!inpt.good())
-	error("Combined: couldn't open file \"%s\" for input\n",file);
+	error((char*)"Combined: couldn't open file \"%s\" for input\n",file);
       char Line[size], AccName[size], AccPars[size], AccFile[size];
       char*accname=0, *accpars=0, *accfile=0, unknown[9];
       read_line(inpt,Line,size);
       if(*Line == 0)
-	error("Combined: couldn't read data from file \"%s\"\n",file);
+	error((char*)"Combined: couldn't read data from file \"%s\"\n",file);
       if(strncmp(Line,"accname=",8))
-	error("Combined: first entry in file \"%s\" isn't \"accname=...\"\n",
+	error((char*)"Combined: first entry in file \"%s\" isn't \"accname=...\"\n",
 	      file);
       N = 0;
       nemo_dprintf (1," sub-potentials:\n");
@@ -261,7 +261,7 @@ namespace {
 	read_line(inpt,Line,size);
 	if        (*Line == 0 || 0==strncmp(Line,"accname=",8)) {
 	  if(N == NMAX)
-	    error("Combined: file \"%s\" contains more accname= "
+	    error((char*)"Combined: file \"%s\" contains more accname= "
 		  "than anticipated\n",file);
 	  //       // TEST
 	  //       std::cerr<<"loading acceleration "<<N<<": \n"
@@ -281,25 +281,25 @@ namespace {
 	  accname=0;
 	} else if(0==strncmp(Line,"accpars=",8)) {
 	  if(accpars)
-	    warning("Combined: additional \"accpars=\""
-		    " in file \"%s\" ignored\n",file);
+	    warning((char*)"Combined: additional \"accpars=\""
+					" in file \"%s\" ignored\n",file);
 	  else {
 	    strcpy(AccPars,Line+8);
 	    accpars = AccPars;
 	  }
 	} else if(0==strncmp(Line,"accfile=",8)) {
 	  if(accfile)
-	    warning("Combined: additional \"accfile=\""
-		    " in file \"%s\" ignored\n",file);
+	    warning((char*)"Combined: additional \"accfile=\""
+					" in file \"%s\" ignored\n",file);
 	  else {
 	    strcpy(AccFile,Line+8);
 	    accfile = AccFile;
 	    if(0==strcmp(file,accfile))
-	      error("Combined: recursion accfile=datafile not allowed\n");
+	      error((char*)"Combined: recursion accfile=datafile not allowed\n");
 	  }
 	} else {
 	  strncpy(unknown,Line,8); unknown[8]=0;
-	  warning("Combined: entry \"%s\" in file \"%s\" ignored\n",
+	  warning((char*)"Combined: entry \"%s\" in file \"%s\" ignored\n",
 		  unknown,file);
 	}
       } while(*Line != 0);
@@ -336,7 +336,7 @@ namespace {
 				static_cast<      float*>(p),
 				static_cast<      float*>(a),
 				add);
-	default: error("Combined: unsupported ndim: %d",ndim);
+	default: error((char*)"Combined: unsupported ndim: %d",ndim);
 	}
 	break;
       case 'd':
@@ -357,10 +357,10 @@ namespace {
 				static_cast<      double*>(p),
 				static_cast<      double*>(a),
 				add);
-	default: error("Combined: unsupported ndim: %d",ndim);
+	default: error((char*)"Combined: unsupported ndim: %d",ndim);
 	}
 	break;
-      default: error("Combined: unknown type \"%c\"",type);
+      default: error((char*)"Combined: unknown type \"%c\"",type);
       }
     } // Combined::acc()
   } *MyAcc[AccMax] = {0};
@@ -410,8 +410,8 @@ void iniacceleration(const double*pars,      // I:  array with parameters
 		     bool        *needV)     // O:  acceleration() needs vel's? 
 {
   if(AccN == AccMax) {
-    warning("iniacceleration(): request to initialize "
-	    "more than %d accelerations of type \"Combined\"", AccMax);
+    warning((char*)"iniacceleration(): request to initialize "
+		"more than %d accelerations of type \"Combined\"", AccMax);
     *accel = 0;
     return;
   }

--- a/usr/dehnen/falcON/src/public/acc/Combined.cc
+++ b/usr/dehnen/falcON/src/public/acc/Combined.cc
@@ -79,7 +79,7 @@ namespace {
       } while(isspace(*line));
       // 2. read line until first white-space character
       //    swallow rest til EOL, if necessary 
-      register char*l=line+1;
+       char*l=line+1;
       const    char*L=line+n;
       while(l != L) {
 	from.get(*l);

--- a/usr/dehnen/falcON/src/public/acc/Dehnen.cc
+++ b/usr/dehnen/falcON/src/public/acc/Dehnen.cc
@@ -39,7 +39,7 @@ namespace {
 	   const char  *file)
     {
       if(npar < 5)
-	warning("%s: recognizing 5 parameters:\n"
+	warning((char*)"%s: recognizing 5 parameters:\n"
 		" omega        pattern speed (ignored)           [0]\n"
 		" gamma        inner density slope               [1]\n"
 		" G*M          mass;                             [1]\n"
@@ -52,7 +52,7 @@ namespace {
 		"with\n\n"
 		"    r   = sqrt(x^2+e^2)\n\n",name());
       if(file && file[0])
-	warning("%s: file \"%s\" ignored",name(),file);
+	warning((char*)"%s: file \"%s\" ignored",name(),file);
       double o,e,m;
       o     = npar>0? pars[0] : 0.;
       g     = npar>1? pars[1] : 1.;
@@ -64,7 +64,7 @@ namespace {
       GM    = -m;
       Pf    = g==1? GM        : g==2? m/Rs  : -m/Rs/g2;
       model = g==1? hernquist : g==2? jaffe : general;
-      if(npar>5) warning("%s: skipped parameters beyond 5",name());
+      if(npar>5) warning((char*)"%s: skipped parameters beyond 5",name());
       nemo_dprintf (1,
 		    "initializing %s\n"
 		    " parameters : pattern speed = %f (ignored)\n"

--- a/usr/dehnen/falcON/src/public/acc/Dehnen.cc
+++ b/usr/dehnen/falcON/src/public/acc/Dehnen.cc
@@ -79,7 +79,7 @@ namespace {
 		scalar      &P,
 		scalar      &T) const
     {
-      register scalar R=std::sqrt(Eq+Rq);
+       scalar R=std::sqrt(Eq+Rq);
       T = 1/(R+Rs);
       switch(model) {
       case hernquist: {
@@ -94,7 +94,7 @@ namespace {
       } break;
       default: {
 	// general gamma!=2
-	register scalar Q = std::pow(double(R*T),g2);
+	 scalar Q = std::pow(double(R*T),g2);
 	P  = Pf*(1-Q);
 	T *= GM*Q/(R*R);
       } break;

--- a/usr/dehnen/falcON/src/public/acc/DehnenMcLaughlin.cc
+++ b/usr/dehnen/falcON/src/public/acc/DehnenMcLaughlin.cc
@@ -69,15 +69,15 @@ namespace {
 	  "    eta= 2*(e-2)*(2-b0)/(6+e)  [4/9]\n"
 	  "    g0 = 1-eta/2+b0            [7/9]\n\n";
       if(file)
-	warning("acceleration \"%s\": file \"%s\" ignored",name(),file);
+	warning((char*)"acceleration \"%s\": file \"%s\" ignored",name(),file);
       if(a<=0.)
-	error("acceleration \"%s\": a=%f <= 0\n",name(),a);
+	error((char*)"acceleration \"%s\": a=%f <= 0\n",name(),a);
       if(e<=2.)
-	error("acceleration \"%s\": e=%f <= 2\n",name(),e);
+	error((char*)"acceleration \"%s\": e=%f <= 2\n",name(),e);
       if(b0>1.)
-	error("acceleration \"%s\": b0=%f > 1\n",name(),b0);
-      if(npar>5) warning("acceleration \"%s\":"
-			 " skipped parameters beyond 5",name());
+	error((char*)"acceleration \"%s\": b0=%f > 1\n",name(),b0);
+      if(npar>5) warning((char*)"acceleration \"%s\":"
+                        " skipped parameters beyond 5",name());
     }
     ///                                                                         
     /// routine used by class SphericalPot<DehnenMcLaughlin> of defacc.h        

--- a/usr/dehnen/falcON/src/public/acc/DiscPot.cc
+++ b/usr/dehnen/falcON/src/public/acc/DiscPot.cc
@@ -94,7 +94,7 @@ namespace {
 	  "   h(z) = delta(z)                       if z_d = 0\n"
 	  "          sech^2(z/2|z_d|) / (4|z_d|)    if z_d < 0\n\n";
       if (npar>6)
-	warning("Skipped potential parameters for DiscPot beyond %d", npar);
+	warning((char*)"Skipped potential parameters for DiscPot beyond %d", npar);
       if(nemo_debug(2))
 	std::cerr<<
 	  "### nemo debug info:\n"

--- a/usr/dehnen/falcON/src/public/acc/GalPot.cc
+++ b/usr/dehnen/falcON/src/public/acc/GalPot.cc
@@ -70,10 +70,10 @@ namespace {
     GalaxyFile(const char*file)
     {
       if(file==0 || file[0]==0) 
-	::error("Need data file to initialize GalPot");
+	::error((char*)"Need data file to initialize GalPot");
       from.open(file);
       if(!from.is_open())
-	::error("GalPot: cannot open file \"%s\"",file);
+	::error((char*)"GalPot: cannot open file \"%s\"",file);
       nemo_dprintf(4,"file \"%s\" opened\n",file);
     }
   };

--- a/usr/dehnen/falcON/src/public/acc/Halo.cc
+++ b/usr/dehnen/falcON/src/public/acc/Halo.cc
@@ -41,8 +41,9 @@ namespace {
       if(def == DPLH::null_value())
 	return par?  *par : 7./9.;
       else if(par && *par != def)
-	falcON_WarningN("external potential \"Halo\": "
+	falcON_WarningN((char*)"external potential \"Halo\": "
 			"par[3]=g_i=%g ignored, using g_i=%g for model '%s'",
+
 			*par, def, model);
       return def;
     }
@@ -53,8 +54,9 @@ namespace {
       if(def == DPLH::null_value())
 	return par?  *par : 31./9.;
       else if(par && *par != def)
-	falcON_WarningN("external potential \"Halo\": "
+	falcON_WarningN((char*)"external potential \"Halo\": "
 			"par[4]=g_o=%g ignored, using g_o=%g for model '%s'",
+
 			*par, def, model);
       return def;
     }
@@ -65,8 +67,9 @@ namespace {
       if(def == DPLH::null_value())
 	return par?  *par : 4./9.;
       else if(par && *par != def)
-	falcON_WarningN("external potential \"Halo\": "
+	falcON_WarningN((char*)"external potential \"Halo\": "
 			"par[5]=eta=%g ignored, using eta=%g for model '%s'",
+
 			*par, def, model);
       return def;
     }
@@ -126,7 +129,7 @@ namespace {
 	  "   r_c = "<<core_radius() <<'\n';
       }
       if(npar>8)
-	falcON_Warning("external potential \"Halo\": "
+	falcON_Warning((char*)"external potential \"Halo\": "
 		       "skipping parameters beyond 8\n");
     }
     //--------------------------------------------------------------------------

--- a/usr/dehnen/falcON/src/public/acc/LogPot.cc
+++ b/usr/dehnen/falcON/src/public/acc/LogPot.cc
@@ -51,13 +51,13 @@ namespace {
       : VQ ( npar>1? pars[1] : 1),
       	RQ ( npar>2? pars[2] : 0)
     {
-      if(VQ<=0) error("LogPot: circular speed <=0\n");
-      if(RQ< 0) error("LogPot: core radius <0\n");
+      if(VQ<=0) error((char *) "LogPot: circular speed <=0\n");
+      if(RQ< 0) error((char *) "LogPot: core radius <0\n");
       double CA = npar>3? pars[3] : 1;
       double BA = npar>4? pars[4] : 1;
-      if(CA<=0 || CA> 1) error("LogPot: major axis ratio = %g",CA);
-      if(BA<=0) error("LogPot: minor axis ratio = %g",BA);
-      if(BA>CA) error("LogPot: minor axis ratio = %g > %g = major axis ratio",
+      if(CA<=0 || CA> 1) error((char *) "LogPot: major axis ratio = %g",CA);
+      if(BA<=0) error((char *) "LogPot: minor axis ratio = %g",BA);
+      if(BA>CA) error((char *) "LogPot: minor axis ratio = %g > %g = major axis ratio",
 		      BA,CA);
       iQ[0] = std::pow(CA*BA,2./3.);
       iQ[1] = iQ[0] / (BA*BA);
@@ -101,7 +101,7 @@ namespace {
 	A[2]*= sQ;
       } else
 	P = A[0] = A[1] = A[2] = 0;
-	error("LogPot: wrong number (%d) of dimensions, only allow 3D\n",NDIM);
+	error((char *) "LogPot: wrong number (%d) of dimensions, only allow 3D\n",NDIM);
     }
   };
 } // namespace {

--- a/usr/dehnen/falcON/src/public/acc/MiyamotoNagai.cc
+++ b/usr/dehnen/falcON/src/public/acc/MiyamotoNagai.cc
@@ -94,7 +94,7 @@ namespace {
 	       scalar             &pot,
 	       scalar             *acc)
     {
-      register scalar
+       scalar
 	ZB   = std::sqrt(pos[2]*pos[2]+POT.Bq),
 	AZ   = POT.A+ZB,
 	F    = 1/(pos[0]*pos[0]+pos[1]*pos[1]+AZ*AZ);
@@ -113,7 +113,7 @@ namespace {
 	       scalar             &pot,
 	       scalar             *acc)
     {
-      register scalar
+       scalar
 	F    = 1/(pos[0]*pos[0]+pos[1]*pos[1]+POT.ABq);
       pot    = POT.GM * sqrt(F);
       F     *= pot;

--- a/usr/dehnen/falcON/src/public/acc/MiyamotoNagai.cc
+++ b/usr/dehnen/falcON/src/public/acc/MiyamotoNagai.cc
@@ -69,7 +69,7 @@ namespace {
       GM  =-m;
       Bq  = b*b;
       ABq = (A+b)*(A+b);
-      if(npar>4) warning("%s: skipped parameters beyond 4",name());
+      if(npar>4) warning((char*)"%s: skipped parameters beyond 4",name());
       nemo_dprintf (1,
 		    " initializing %s:\n"
 		    " parameters : pattern speed = %f (ignored)\n"

--- a/usr/dehnen/falcON/src/public/acc/Monopole.cc
+++ b/usr/dehnen/falcON/src/public/acc/Monopole.cc
@@ -197,7 +197,7 @@ namespace {
     } while(isspace(*line));
     // 2. read line until first white-space character
     //    swallow rest til EOL, if necessary 
-    register char*l=line+1;
+     char*l=line+1;
     const    char*L=line+n;
     while(l != L) {
       from.get(*l);

--- a/usr/dehnen/falcON/src/public/acc/Monopole.cc
+++ b/usr/dehnen/falcON/src/public/acc/Monopole.cc
@@ -137,7 +137,7 @@ namespace {
 				static_cast<      float*>(p),
 				static_cast<      float*>(a),
 				add);
-	default: error("Monopole: unsupported ndim: %d",ndim);
+	default: error((char*)"Monopole: unsupported ndim: %d",ndim);
 	}
 	break;
       case 'd':
@@ -158,10 +158,10 @@ namespace {
 				static_cast<      double*>(p),
 				static_cast<      double*>(a),
 				add);
-	default: error("Monopole: unsupported ndim: %d",ndim);
+	default: error((char*)"Monopole: unsupported ndim: %d",ndim);
 	}
 	break;
-      default: error("Monopole: unknown type \"%c\"",type);
+      default: error((char*)"Monopole: unknown type \"%c\"",type);
       }
     }
     //--------------------------------------------------------------------------
@@ -209,7 +209,7 @@ namespace {
       }
       ++l;
     }
-    error("Combined: line longer than expected\n");
+    error((char *)("Combined: line longer than expected\n"));
   }
   //////////////////////////////////////////////////////////////////////////////
   bool read_line(std::istream& from, char*line, int const&n)
@@ -286,7 +286,7 @@ namespace {
       klo = int( (xi-x[0]) / (x[n-1]-x[0]) * (n-1) );
       klo = hunt(x,n,xi,klo);
       if(klo<0 || klo>=n) 
-	error("[%s.%d]: in %s: %s",__FILE__,__LINE__,"x out of range","find()");
+	error((char*)"[%s.%d]: in %s: %s",__FILE__,__LINE__,(char*)"x out of range",(char*)"find()");
     }
   }
   //////////////////////////////////////////////////////////////////////////////
@@ -351,7 +351,7 @@ namespace {
     {
       const scalar_type ife=1./48.;
       scalar_type h =x1-x0;
-      if(h==0) error("penta_splines::evaluate(): bad x input");
+      if(h==0) error((char*)"penta_splines::evaluate(): bad x input");
       scalar_type
 	hi = scalar_type(1)/h,
 	hf = h*h,
@@ -512,15 +512,15 @@ namespace {
 	"  par[3] = outermost radius in table for monopole       [1000]\n"
 	"  par[4] = number of points in table for monopole       [1001]\n\n";
     if(npar>5)
-      warning("Monopole: skipped parameters beyond 6\n");
+      warning((char*)("Monopole: skipped parameters beyond 6\n"));
     nemo_dprintf(4,"Monopole: timer set to: %s with t0=%f, tau=%f\n",
 		 timer::describe(), timer::T0(), timer::TAU());
     if(NR < 2)
-      error("Monopole: NR=%d < 2\n",NR);
+      error((char*)"Monopole: NR=%d < 2\n",NR);
     if(NR < 10)
-      warning("Monopole: NR=%d < 10\n",NR);
+      warning((char*) "Monopole: NR=%d < 10\n",NR);
     if(file==0|| file[0]==0)
-      error("Monopole: no accfile given\n");
+      error((char*)"Monopole: no accfile given\n");
     //
     // 1. scan data file for accname, accpars, accfile, and initialize Phi
     //
@@ -528,42 +528,42 @@ namespace {
     const int size=256;
     std::ifstream inpt(file);
     if(! inpt.good())
-      error("Monopole: couldn't open file \"%s\" for input\n",file);
+      error((char*)"Monopole: couldn't open file \"%s\" for input\n",file);
     char Line[size], AccName[size], AccPars[size], AccFile[size];
     char*accname=0, *accpars=0, *accfile=0, unknown[9];
     if(! read_line(inpt,Line,size))
-      error("Monopole: couldn't read data from file \"%s\"\n",file);
+      error((char*)"Monopole: couldn't read data from file \"%s\"\n",file);
     do {
       if       (0==strncmp(Line,"accname=",8)) {
 	if(accname)
-	  error("Monopole: >1 accname= entry in file \"%s\"\n",file);
+	  error((char*)"Monopole: >1 accname= entry in file \"%s\"\n",file);
 	else {
 	  strcpy(AccName,Line+8);
 	  accname=AccName;
 	}
       } else if(0==strncmp(Line,"accpars=",8)) {
 	if(accpars)
-	  warning("Monopole: extra accpars= in file \"%s\" ignored\n",file);
+	  warning((char*) "Monopole: extra accpars= in file \"%s\" ignored\n",file);
 	else {
 	  strcpy(AccPars,Line+8);
 	  accpars=AccPars;
 	}
       } else if(0==strncmp(Line,"accfile=",8)) {
 	if(accfile)
-	  warning("Monopole: extra accfile= in file \"%s\" ignored\n",file);
+	  warning((char*)"Monopole: extra accfile= in file \"%s\" ignored\n",file);
 	else {
 	  strcpy(AccFile,Line+8);
 	  accfile=AccFile;
 	}
       } else {
 	strncpy(unknown,Line,8); unknown[8]=0;
-	warning("Monopole: entry \"%s\" in file \"%s\" ignored\n",
+	warning((char*)"Monopole: entry \"%s\" in file \"%s\" ignored\n",
 		unknown,file);
       }
     }
     while(read_line(inpt,Line,size));
     if(accname == 0)
-      error("Monopole: no accname= entry found in file \"%s\"\n",file);
+      error((char*)"Monopole: no accname= entry found in file \"%s\"\n",file);
     nemo_dprintf(4,"Monopole: successfully scanned accfile:\n");
     nemo_dprintf(4,"	       accname=%s\n",accname);
     if(accpars) nemo_dprintf(4,"	       accpars=%s\n",accpars);
@@ -572,9 +572,9 @@ namespace {
     bool m(0),v(0);
     PHI = get_acceleration(accname,accpars,accfile,&m,&v);
     if(PHI==0)
-      error("Monopole: cannot obtain conservative potential\n");
+      error((char*) "Monopole: cannot obtain conservative potential\n");
     if(m || v)
-      error("Monopole: Phi(x) not conservative\n");
+      error((char*)"Monopole: Phi(x) not conservative\n");
     //
     // 2. initialize tables and compute monopole
     //
@@ -773,8 +773,8 @@ void iniacceleration(const double*pars,      // I:  array with parameters
 		     bool        *needV)     // O:  acceleration() needs vel's? 
 {
   if(AccN == AccMax) {
-    warning("iniacceleration(): request to initialize "
-	    "more than %d accelerations of type \"Monopole\"", AccMax);
+    warning((char*)"iniacceleration(): request to initialize "
+		"more than %d accelerations of type \"Monopole\"", AccMax);
     *accel = 0;
     return;
   }

--- a/usr/dehnen/falcON/src/public/acc/NFW.cc
+++ b/usr/dehnen/falcON/src/public/acc/NFW.cc
@@ -50,16 +50,16 @@ namespace {
 	   const char  *file)
     {
       if(npar < 3)
-	warning("%s: recognizing 3 parameters:\n"
-		" omega        pattern speed (ignored)           [0]\n"
-		" a            scale radius;                     [1]\n"
-		" vc_max       maximum circular speeed           [1]\n"
-		"the density is proportional to\n\n"
-		"        1    \n"
-                "    -------- \n" 
+	warning((char*)"%s: recognizing 3 parameters:\n"\
+		" omega        pattern speed (ignored)           [0]\n"\
+		" a            scale radius;                     [1]\n"\
+		" vc_max       maximum circular speeed           [1]\n"\
+		"the density is proportional to\n\n"\
+		"        1    \n"\
+                "    -------- \n"\
 		"    r (r+a)^2\n\n",name());
       if(file)
-	warning("%s: file \"%s\" ignored",name(),file);
+	warning((char*)"%s: file \"%s\" ignored",name(),file);
       double
 	o   = npar>0? pars[0] : 0.;
       A     = npar>1? pars[1] : 1.;
@@ -67,7 +67,7 @@ namespace {
       double
 	v   = npar>2? pars[2] : 1.;
       Fac   = A * v*v / 0.2162165954;
-      if(npar>3) warning("%s: skipped parameters beyond 3",name());
+      if(npar>3) warning((char*)"%s: skipped parameters beyond 3",name());
       nemo_dprintf (1,"initializing %s\n",name());
       nemo_dprintf (1," parameters : pattern speed = %f (ignored)\n",o);
       nemo_dprintf (1,"              scale radius  = %f\n",A);

--- a/usr/dehnen/falcON/src/public/acc/NFW.cc
+++ b/usr/dehnen/falcON/src/public/acc/NFW.cc
@@ -79,7 +79,7 @@ namespace {
 		scalar      &P,
 		scalar      &fR) const
     {
-      register scalar
+       scalar
 	R = std::sqrt(Rq),
 	iR= 1/R;
       fR  = std::log(1+iA*R) * iR;

--- a/usr/dehnen/falcON/src/public/acc/Plummer.cc
+++ b/usr/dehnen/falcON/src/public/acc/Plummer.cc
@@ -38,23 +38,23 @@ namespace {
 	    const char  *file)
     {
       if(npar < 3)
-	warning("%s: recognizing 3 parameters:\n"
-		" omega        pattern speed (ignored)           [0]\n"
-		" G*M          mass;                             [1]\n"
-		" a            scale radius;                     [1]\n"
-		"\nthe potential is given by\n\n"
-		"                 G*M\n"
-                "    Phi = - ---------------\n"
+	warning((char*)"%s: recognizing 3 parameters:\n"\
+		" omega        pattern speed (ignored)           [0]\n"\
+		" G*M          mass;                             [1]\n"\
+		" a            scale radius;                     [1]\n"\
+		"\nthe potential is given by\n\n"\
+		"                 G*M\n"\
+                "    Phi = - ---------------\n"\
 		"            sqrt(a^2 + r^2)\n\n",name());
       if(file && file[0])
-	warning("%s: file \"%s\" ignored",name(),file);
+	warning((char*)"%s: file \"%s\" ignored",name(),file);
       double
 	o   = npar>0? pars[0] : 0.,
 	m   = npar>1? pars[1] : 1.,
 	a   = npar>2? pars[2] : 1.;
       Aq    = a*a;
       GM    = -m;
-      if(npar>3) warning("%s: skipped parameters beyond 3",name());
+      if(npar>3) warning((char*)"%s: skipped parameters beyond 3",name());
       nemo_dprintf (1,
 		    "initializing %s\n"
 		    " parameters : pattern speed = %f (ignored)\n"

--- a/usr/dehnen/falcON/src/public/acc/Point.cc
+++ b/usr/dehnen/falcON/src/public/acc/Point.cc
@@ -46,15 +46,15 @@ namespace {
       Kl ( npar>3? int(pars[3]) : 0 )
     {
       if(npar < 3)
-	warning("%s: recognizing 4 parameters:\n"
-		" omega        pattern speed (ignored)           [0]\n"
-		" G*M          mass;                             [1]\n"
-		" a            scale radius;                     [1]\n"
+	warning((char*)"%s: recognizing 4 parameters:\n"\
+		" omega        pattern speed (ignored)           [0]\n"\
+		" G*M          mass;                             [1]\n"\
+		" a            scale radius;                     [1]\n"\
 		" kernel       use falcON's P_n kernel           [0]\n",
 		name());
       if(file)
-	warning("%s: file \"%s\" ignored",name(),file);
-      if(npar>4) warning("%s: skipped parameters beyond 4",name());
+	warning((char*)"%s: file \"%s\" ignored",name(),file);
+      if(npar>4) warning((char*)"%s: skipped parameters beyond 4",name());
       nemo_dprintf (1,
 		    "initializing %s\n"
 		    " parameters : mass          = %f\n"

--- a/usr/dehnen/falcON/src/public/acc/Shrink.cc
+++ b/usr/dehnen/falcON/src/public/acc/Shrink.cc
@@ -96,7 +96,7 @@ namespace {
 	if(from.eof() || (*l)=='\n') { *l=0; return; }
 	++l;
       }
-      error("Shrink: line longer than expected\n");
+      error((char*)"Shrink: line longer than expected\n");
     }
     /// read line of size n; skip lines whose first non-space character is #
     static void read_line(std::istream& from, char*line, int const&n)
@@ -172,7 +172,7 @@ namespace {
       scalar alpha = Alpha(time);
       // if alpha = 0: issue warning! and set zero velocities
       if(alpha == 0) {
-	warning("Shrink: alpha(t=%f) = 0\n",time);
+	warning((char *) "Shrink: alpha(t=%f) = 0\n",time);
 	if(! (add&1))
 	  for(int n=0; n!=nbod; ++n)
 	    if(f==0 || f[n] & 1) 
@@ -231,13 +231,13 @@ namespace {
 	   const char  *file) : NEEDM(0), NEEDV(0)
     {
       if(npar < 5 || file==0)
-	warning("Shrink: recognizes 3 parameters and requires a data file.\n"
+	warning((char*)"Shrink: recognizes 3 parameters and requires a data file.\n"
 		"parameters:\n"
 		"  par[0] = initial value for alpha                    [???]\n"
 		"  par[1] = final value for alpha                      [???]\n"
 		"  par[2] = controlling growth factor, see below         [9]\n"
 		"  par[3] = t0: start time for growth                    [0]\n"
-		"  par[4] = tau: time scale for growth                   [1]\n"
+		"  par[4] = tau: time constant for growth                   [1]\n"
 		"  with par[2]=0: %s\n"
 		"       par[2]=1: %s\n"
 		"       par[2]=2: %s\n"
@@ -253,7 +253,7 @@ namespace {
 		timer::describe(timer::linear),
 		timer::describe(timer::constant),
 		NMAX);
-      if(file == 0) error("Shrink: not data file given");
+      if(file == 0) error((char*)"Shrink: not data file given");
       // initialize parameters
       AlfaI = pars[0];
       AlfaF = pars[1];
@@ -263,7 +263,7 @@ namespace {
 	_t0    = npar>3? pars[3] : 0.,
 	_tau   = npar>4? pars[4] : 1.;
       timer::init(timin,_t0,_tau);
-      if(npar>5) warning("Shrink: skipped parameters beyond 5");
+      if(npar>5) warning((char*)"Shrink: skipped parameters beyond 5");
       nemo_dprintf (1,
 		    "initializing Shrink\n"
 		    " parameters : alpha_i       = %f\n"
@@ -276,7 +276,7 @@ namespace {
       const int size=1024;
       std::ifstream inpt(file);
       if(!inpt.good())
-	error("Shrink: couldn't open file \"%s\" for input\n",file);
+	error((char*)"Shrink: couldn't open file \"%s\" for input\n",file);
       char Line[size], AccName[size], AccPars[size], AccFile[size];
       char*accname=0, *accpars=0, *accfile=0;
       nemo_dprintf (1,"sub-potentials:\n");
@@ -289,7 +289,7 @@ namespace {
 	  copy2ws(AccName,accname+8);
 	  accname=AccName;
 	} else {
-	  warning("Shrink: entry \"%s\" in file \"%s\" ignored\n",
+	  warning((char*) "Shrink: entry \"%s\" in file \"%s\" ignored\n",
 		  Line,file);
 	  continue;
 	}
@@ -317,15 +317,15 @@ namespace {
 	N++;
       }
       if(N==0)
-	error("Shrink: couldn't read data from file \"%s\"\n",file);
+	error((char*)"Shrink: couldn't read data from file \"%s\"\n",file);
       else if(N==NMAX) {
 	read_line(inpt,Line,size);
 	if(*Line)
-	  error("Shrink: file \"%s\" contains more \"accname=...\" "
+	  error((char*)"Shrink: file \"%s\" contains more \"accname=...\" "
 		"than anticipated\n",file);
       }
-      if(NEEDM) warning("Shrink: need_masses() = true:\n");
-      if(NEEDV) warning("Shrink: need_velocities() = true:\n");
+      if(NEEDM) warning((char*)"Shrink: need_masses() = true:\n");
+      if(NEEDV) warning((char*)"Shrink: need_velocities() = true:\n");
     }
     /// compute accelerations
     /// \param[in]  ndim  # dimensions  
@@ -362,7 +362,7 @@ namespace {
 				static_cast<      float*>(p),
 				static_cast<      float*>(a),
 				add);
-	default: error("Shrink: unsupported ndim: %d",ndim);
+	default: error((char*)"Shrink: unsupported ndim: %d",ndim);
 	}
 	break;
       case 'd':
@@ -383,10 +383,10 @@ namespace {
 				static_cast<      double*>(p),
 				static_cast<      double*>(a),
 				add);
-	default: error("Shrink: unsupported ndim: %d",ndim);
+	default: error((char*)"Shrink: unsupported ndim: %d",ndim);
 	}
 	break;
-      default: error("Shrink: unknown type \"%c\"",type);
+      default: error((char*)"Shrink: unknown type \"%c\"",type);
       }
     }
     /// dtor
@@ -443,8 +443,8 @@ void iniacceleration(const double*pars,      // I:  array with parameters
 		     bool        *needV)     // O:  acceleration() needs vel's? 
 {
   if(AccN == AccMax) {
-    warning("iniacceleration(): request to initialize "
-	    "more than %d accelerations of type \"Shrink\"", AccMax);
+    warning((char*) "iniacceleration(): request to initialize "
+		"more than %d accelerations of type \"Shrink\"", AccMax);
     *accel = 0;
     return;
   }

--- a/usr/dehnen/falcON/src/public/acc/Shrink.cc
+++ b/usr/dehnen/falcON/src/public/acc/Shrink.cc
@@ -89,7 +89,7 @@ namespace {
 	}
       } while(isspace(*line));
       // 2. read line until EOL
-      register char*l=line+1;
+       char*l=line+1;
       const    char*L=line+n;
       while(l != L) {
 	from.get(*l);

--- a/usr/dehnen/falcON/src/public/exe/TestGrav.cc
+++ b/usr/dehnen/falcON/src/public/exe/TestGrav.cc
@@ -47,7 +47,7 @@ using namespace falcON;
 namespace {
   double ms_Force_gamma(const double gamma)
   {
-    register double x=5-3*gamma,f;
+     double x=5-3*gamma,f;
     if(x < 0.) return 0.;
     f =1/x;
     f-=4/(x+=1);
@@ -112,7 +112,7 @@ void falcON::main(int argc, const char* argv[]) falcON_THROWING
       " DUMP (default   0)  : [0/1] dump nodes to tree.cells and tree.leafs\n";
     std::exit(1);
   }
-  register clock_t  cpu0 = clock(), cpu1;
+   clock_t  cpu0 = clock(), cpu1;
 #ifdef falcON_ADAP
   real              Nsoft=zero,emin=zero;
   unsigned          NREF;
@@ -237,7 +237,7 @@ void falcON::main(int argc, const char* argv[]) falcON_THROWING
   if(indiv_soft) {
     std::cerr<<" indiv_soft = "<<indiv_soft<<'\n';
     std::cerr<<" epar       = "<<EPAR<<'\n';
-    register double emean=0.;
+     double emean=0.;
     LoopAllBodies(BODIES,Bi) {
       Bi.eps() = min(EPS, real(EPAR*pow(RH[bodyindex(Bi)]*rho,-1./3.)));
       emean   += eps(Bi);
@@ -271,7 +271,7 @@ void falcON::main(int argc, const char* argv[]) falcON_THROWING
       <<(cpu1 - cpu0)/real(CLOCKS_PER_SEC)<<endl;
   cpu0 = cpu1;
   forces falcon(BODIES,EPS,theta,K,indiv_soft,one,MAC,EPS,one,DIR);
-  for(register unsigned ig=0; ig<=Ngrow; ++ig) {
+  for( unsigned ig=0; ig<=Ngrow; ++ig) {
 #if (0)
     if(Ncut) falcon.re_grow(Ncut,Ncrit);
     else     

--- a/usr/dehnen/falcON/src/public/exe/TestPair.cc
+++ b/usr/dehnen/falcON/src/public/exe/TestPair.cc
@@ -34,7 +34,7 @@ void dmintmin(const bodies *BODS,
     tmin = zero;
     dmin = sqrt(dist_sq(BODS->pos(A),BODS->pos(B)));
   } else {
-    register vect R = BODS->pos(A)-BODS->pos(B), V=BODS->vel(A)-BODS->vel(B);
+     vect R = BODS->pos(A)-BODS->pos(B), V=BODS->vel(A)-BODS->vel(B);
     tmin = max(zero, min(T, -(R*V)/norm(V)));
     dmin = sqrt(norm(R+tmin*V));
   }
@@ -59,8 +59,8 @@ void falcON::main(int argc, char* argv[]) falcON_THROWING
     exit(1);
   }
 
-  register clock_t      cpu0 = clock(), cpu1;
-  register real         time_prep, time_tree, time_subt;
+   clock_t      cpu0 = clock(), cpu1;
+   real         time_prep, time_tree, time_subt;
   int                   p=1, T=0, Mx=1, Count=0;
   long                  Seed;
   unsigned              N, NS, Ncrit=Default::Ncrit;
@@ -80,7 +80,7 @@ void falcON::main(int argc, char* argv[]) falcON_THROWING
 
   bodies         *BODIES = new bodies(N,fieldset(bodies::DefBits),NS);
   const    real   mass=1./real(N);
-  register double M,r,rq,P,Pot,veq,f0,v,vq,fs,R,cth,phi;
+   double M,r,rq,P,Pot,veq,f0,v,vq,fs,R,cth,phi;
   LoopAllBodies(BODIES,Bi) {
     M   = pow(drand48(),twothird);
     rq  = M/(1-M);
@@ -141,7 +141,7 @@ void falcON::main(int argc, char* argv[]) falcON_THROWING
   time_subt = (cpu1 - cpu0) / real(CLOCKS_PER_SEC);
   cerr<<" tree.make_iaction_list() used "<<time_subt<<" seconds \n";
 
-  register unsigned i;
+   unsigned i;
   if(TAU<zero) {
     ofstream out("pairs.c++");
     for(i=0; i!=min(NS,Na); ++i) {

--- a/usr/dehnen/falcON/src/public/exe/gyrfalcON.cc
+++ b/usr/dehnen/falcON/src/public/exe/gyrfalcON.cc
@@ -147,9 +147,10 @@
 // v 3.5    15/06/2011  WD recompute forces if manipulator changes masses
 // v 3.5.1  30/06/2011  WD eps required (no default value)
 // v 3.6    19/06/2011  WD happy gcc 4.7.0
+// v 3.7    07/10/2025  JCL support for std++11
 ////////////////////////////////////////////////////////////////////////////////
-#define falcON_VERSION   "3.6"
-#define falcON_VERSION_D "19-jun-2012 Walter Dehnen                          "
+#define falcON_VERSION   "3.7"
+#define falcON_VERSION_D "7-oct-2025 Walter Dehnen                             "
 //------------------------------------------------------------------------------
 #ifndef falcON_NEMO
 #  error You need "NEMO" to compile gyrfalcON

--- a/usr/dehnen/falcON/src/public/exe/mkcold.cc
+++ b/usr/dehnen/falcON/src/public/exe/mkcold.cc
@@ -88,8 +88,8 @@ void nbdy::main()
   Gaussian Gy (&RNG,&RNG,getdparam("b"));
   Gaussian Gz (&RNG,&RNG,getdparam("c"));
   Gaussian Gv (&RNG,&RNG,sigma);
-  register nbdy::real x[3], v[3] = {0.,0.,0.};
-  for(register int n=0; n!=N; ) {
+   nbdy::real x[3], v[3] = {0.,0.,0.};
+  for( int n=0; n!=N; ) {
     x[0] = Gx();
     x[1] = Gy();
     x[2] = Gz();
@@ -99,7 +99,7 @@ void nbdy::main()
       v[2] = Gv();
     }
     if(symmetric)
-      for(register int i=0; i!=8; ++i, ++n) {
+      for( int i=0; i!=8; ++i, ++n) {
 	BB.mass(n)   = mass;
 	BB.pos(n)[0] = i&1 ? x[0] : -x[0];
 	BB.pos(n)[1] = i&2 ? x[1] : -x[1];

--- a/usr/dehnen/falcON/src/public/exe/mkking.cc
+++ b/usr/dehnen/falcON/src/public/exe/mkking.cc
@@ -96,7 +96,7 @@ void falcON::main() falcON_THROWING
   // 2. rescale model to mass and core/tidal radius wanted                      
   //----------------------------------------------------------------------------
   const    double vf = 0.977775320024919, mf = 2.2228847e5;
-  register double mass = getdparam("mass");
+   double mass = getdparam("mass");
   if(getbparam("WD_units")) mass /= mf;
   if(hasvalue("r_t"))
     KM.reset_scales_tidal(mass, getdparam("r_t"));

--- a/usr/dehnen/falcON/src/public/lib/PotExp.cc
+++ b/usr/dehnen/falcON/src/public/lib/PotExp.cc
@@ -389,10 +389,10 @@ namespace {
     //--------------------------------------------------------------------------
     template<class Connector>
     static void Connect(Anlm&A, AnlRec const&P, YlmRec const&Y, scalar x) {
-      register       scalar*Ai = p(A);
-      register const scalar*Pi = p(P);
+             scalar*Ai = p(A);
+       const scalar*Pi = p(P);
       for(int n=0; n!=N1(A); ++n) {
-	register const scalar*Yi = p(Y);
+	 const scalar*Yi = p(Y);
 	for(int l=0; l<L1(A); ++l,++Pi) {
 	  const scalar Pnl = *Pi;
 	  for(int m=-l; m<=l; ++m,++Ai,++Yi)
@@ -403,14 +403,14 @@ namespace {
     //--------------------------------------------------------------------------
 #if 0 // not used
     static scalar Dot(YlmRec const&A, YlmRec const&B) {
-      register scalar x=0.;
+       scalar x=0.;
       for(int i=0; i!=L1Q(A); ++i)
 	x += e(A,i)*e(B,i);
       return x;
     }
     //--------------------------------------------------------------------------
     static scalar Dot(AnlRec const&A, AnlRec const&B) {
-      register scalar x=0.;
+       scalar x=0.;
       for(int i=0; i!=N1(A)*L1(A); ++i)
 	x += e(A,i)*e(B,i);
       return x;
@@ -418,7 +418,7 @@ namespace {
 #endif
     //--------------------------------------------------------------------------
     static scalar Dot(Anlm const&A, Anlm const&B) {
-      register scalar x=0.;
+       scalar x=0.;
       for(int i=0; i!=N1(A)*L1Q(A); ++i)
 	x += e(A,i)*e(B,i);
       return x;
@@ -432,7 +432,7 @@ namespace {
       for(int n=0; n!=N1(A); ++n) {
 	const scalar*Yi = p(Y);
 	for(int l=0; l<L1(A); ++l,++Pi) {
-	  register scalar y=0;
+	   scalar y=0;
 	  for(int m=-l; m<=l; ++m,++Ai,++Yi)
 	    y += *Ai * *Yi;
 	  x += *Pi * y;
@@ -456,7 +456,7 @@ namespace {
 	const scalar*Ti = p(T);
 	const scalar*Qi = p(Q);
 	for(int l=0; l<L1(A); ++l,++Pi,++Ri) {
-	  register scalar y=0,yt=0,yp=0;
+	   scalar y=0,yt=0,yp=0;
 	  for(int m=-l; m<=l; ++m,++Ai,++Yi,++Ti,++Qi) {
 	    y  += *Ai * *Yi;
 	    yt += *Ai * *Ti;
@@ -555,8 +555,8 @@ namespace {
     static void SetYlm(YlmRec&Y,
 		       scalar ct, scalar st, scalar cp, scalar sp) {
       SetPlm(Y,ct,st);                             // set Plm(theta)            
-      register scalar _Cp=1.,Cp;                   // cas( m*phi)               
-      register scalar _Cm=1.,Cm;                   // cas(-m*phi)               
+       scalar _Cp=1.,Cp;                   // cas( m*phi)               
+       scalar _Cm=1.,Cm;                   // cas(-m*phi)               
       for(int m=1; m<L1(Y); ++m) {                 // LOOP m=1...L              
 	Cp = cp * _Cp + sp * _Cm;                  //   C( m) := cas( m*phi)    
 	Cm = cp * _Cm - sp * _Cp;                  //   C(-m) := cas(-m*phi)    
@@ -578,8 +578,8 @@ namespace {
     static void SetYlm(YlmRec&Y, YlmRec&T, YlmRec&P,
 		       scalar ct, scalar st, scalar cp, scalar sp) {
       SetPlm(Y,T,ct,st);                           // set Plm(the), dPlm/dthe   
-      register scalar _Cp=1.,Cp;                   // cas( m*phi)               
-      register scalar _Cm=1.,Cm;                   // cas(-m*phi)               
+       scalar _Cp=1.,Cp;                   // cas( m*phi)               
+       scalar _Cm=1.,Cm;                   // cas(-m*phi)               
       for(int l=0; l<L1(Y); ++l) e(P,l*(l+1))=0;   // dY(l,m=0)/dp=0            
       for(int m=1; m<L1(Y); ++m) {                 // LOOP m=1...L              
 	Cp = cp * _Cp + sp * _Cm;                  //   C( m) := cas( m*phi)    
@@ -622,15 +622,15 @@ namespace {
       for(int l=0,lp=1; lp<L1(P); ++l,++lp)        // LOOP lp=dl...L,1          
 	e(P,lp) = fi * e(P,l);                     //   P(0,l+1) = fi*P(0,l)    
       if(N1(P)==1) return;                         // no terms n>0 --> DONE     
-      register scalar tlm = twice(lambda(0));      // 2*lambda(l=0)             
+       scalar tlm = twice(lambda(0));      // 2*lambda(l=0)             
       const    scalar Dtl = 4*AL;                  // 2*(lambda(l+1)-lambda(l)) 
       const    scalar xi2 = xi+xi;                 // 2*xi                      
       for(int l=0,ln=L1(P);                        // LOOP l=0...L,1            
 	  l<L1(P);                                 //   l+1 runs to L           
 	  ++l,++ln,tlm+=Dtl) {                     //   increment stuff         
 	e(P,ln) = tlm * xi * e(P,l);               //   P(1,l) = 2*lam*xi*P(0,l)
-	register scalar tlmn2xi = (tlm+2)*xi;      //   2*(lam+n)*xi            
-	register scalar tlm1n   = tlm;             //   2*lam+n-1               
+	 scalar tlmn2xi = (tlm+2)*xi;      //   2*(lam+n)*xi            
+	 scalar tlm1n   = tlm;             //   2*lam+n-1               
 	for(int n1= 2,                             //   LOOP n+1=2...N          
 	      im  = l,                             //     i(n-1,l)              
 	      i   = im+L1(P),                      //     i(n  ,l)              
@@ -660,7 +660,7 @@ namespace {
 	e(D,lp) = fi*e(D,l) + dfi*e(P,l);          //   D(0,l+1) = dP(0,l+1)/dr 
       }                                            // END LOOP(l)               
       if(N1(P)==1) return;                         // no terms n>0 --> DONE     
-      register scalar tlm  = twice(lambda(0));     // 2*lambda(l=0)             
+       scalar tlm  = twice(lambda(0));     // 2*lambda(l=0)             
       const    scalar Dtl  = 4*AL;                 // 2*(lambda(l+1)-lambda(l)) 
       const    scalar xi2  = xi+xi;                // 2*xi                      
       const    scalar dxi2 = dxi+dxi;              // d(2*xi)/dr                
@@ -669,9 +669,9 @@ namespace {
 	  ++l,++ln,tlm+=Dtl) {                     //   increment stuff         
 	e(P,ln) = tlm * xi*e(P,l);                 //   P(1,l) = 2*lam*xi*P(0,l)
 	e(D,ln) = tlm *(xi*e(D,l)+dxi*e(P,l));     //   D(1,l) = dP(1,l)/dr     
-	register scalar tlmn2xi  = (tlm+2)*xi;     //   2*(lam+n)*xi            
-	register scalar dtlmn2xi = (tlm+2)*dxi;    //   d(2*(lam+n)*xi)/dr      
-	register scalar tlm1n    = tlm;            //   2*lam+n-1               
+	 scalar tlmn2xi  = (tlm+2)*xi;     //   2*(lam+n)*xi            
+	 scalar dtlmn2xi = (tlm+2)*dxi;    //   d(2*(lam+n)*xi)/dr      
+	 scalar tlm1n    = tlm;            //   2*lam+n-1               
 	for(int n1= 2,                             //   LOOP n+1=2...N          
 	      im  = l,                             //     i(n-1,l)              
 	      i   = im+L1(P),                      //     i(n  ,l)              
@@ -778,7 +778,7 @@ namespace {
     //--------------------------------------------------------------------------
 #if 0 // not used
     static scalar Dot(YlmRec const&A, YlmRec const&B) {
-      register scalar x=0.;
+       scalar x=0.;
       for(int l=0,i=0; l<L1(A); l+=2,i+=4*l-2)
 	for(int m=-l; m<=l; m+=2)
 	  x += e(A,i+m) * e(B,i+m);
@@ -786,7 +786,7 @@ namespace {
     }
     //--------------------------------------------------------------------------
     static scalar Dot(AnlRec const&A, AnlRec const&B) {
-      register scalar x=0.;
+       scalar x=0.;
       for(int n=0,j=0; n!=N1(A); ++n,j+=L1(A))
 	for(int l=0,i=j; l<L1(A); l+=2,i+=2)
 	  x += e(A,i) * e(B,i);
@@ -795,7 +795,7 @@ namespace {
 #endif
     //--------------------------------------------------------------------------
     static scalar Dot(Anlm const&A, Anlm const&B) {
-      register scalar x=0.;
+       scalar x=0.;
       for(int n=0,j=0; n!=N1(A); ++n,j+=L1Q(A))
 	for(int l=0; l<L1(A); l+=2)
 	  for(int m=-l,i=j+l*l; m<=l; m+=2,i+=2)
@@ -813,7 +813,7 @@ namespace {
 	const scalar*Pi = Pn;
 	const scalar*Yl = p(Y);
 	for(int l=0; l<L1(A); l+=2,Al+=4*l-2,Pi+=2,Yl+=4*l-2) {
-	  register scalar y=0;
+	   scalar y=0;
 	  for(int m=-l; m<=l; m+=2)
 	    y += Al[m] * Yl[m];
 	  x += *Pi * y;
@@ -841,7 +841,7 @@ namespace {
 	const scalar*Ql = p(Q);
 	for(int l=0; l<L1(A);
 	    l+=2,Al+=4*l-2,Pi+=2,Ri+=2,Yl+=4*l-2,Tl+=4*l-2,Ql+=4*l-2) {
-	  register scalar y=0,yt=0,yp=0;
+	   scalar y=0,yt=0,yp=0;
 	  for(int m=-l; m<=l; m+=2) {
 	    y  += Al[m] * Yl[m];
 	    yt += Al[m] * Tl[m];
@@ -940,8 +940,8 @@ namespace {
     static void SetYlm(YlmRec&Y,
 		       scalar ct, scalar st, scalar cp, scalar sp) {
       SetPlm(Y,ct,st);                             // set Plm(theta)            
-      register scalar _Cp=1.,Cp;                   // cas( m*phi)               
-      register scalar _Cm=1.,Cm;                   // cas(-m*phi)               
+       scalar _Cp=1.,Cp;                   // cas( m*phi)               
+       scalar _Cm=1.,Cm;                   // cas(-m*phi)               
       const scalar cc=cp*cp-sp*sp, ss=2*cp*sp;
       for(int m=2; m<L1(Y); m+=2) {                // LOOP m=2...L,2            
 	Cp = cc * _Cp + ss * _Cm;                  //   C( m) := cas( m*phi)    
@@ -966,8 +966,8 @@ namespace {
     static void SetYlm(YlmRec&Y, YlmRec&T, YlmRec&P,
 		       scalar ct, scalar st, scalar cp, scalar sp) {
       SetPlm(Y,T,ct,st);                           // set Plm(the), dPlm/dthe   
-      register scalar _Cp=1.,Cp;                   // cas( m*phi)               
-      register scalar _Cm=1.,Cm;                   // cas(-m*phi)               
+       scalar _Cp=1.,Cp;                   // cas( m*phi)               
+       scalar _Cm=1.,Cm;                   // cas(-m*phi)               
       const scalar cc=cp*cp-sp*sp, ss=2*cp*sp;
       for(int l=0; l<L1(Y); l+=2) e(P,l*(l+1))=0;  // dY(l,m=0)/dp=0            
       for(int m=2; m<L1(Y); m+=2) {                // LOOP m=2...L,2            
@@ -1014,15 +1014,15 @@ namespace {
       for(int l=0,lp=2; lp<L1(P); l+=2,lp+=2)      // LOOP lp=dl...L,2          
 	e(P,lp) = fi * e(P,l);                     //   P(0,l+2) = fi^2*P(0,l)  
       if(N1(P)==1) return;                         // no terms n>0 --> DONE     
-      register scalar tlm = twice(lambda(0));      // 2*lambda(l=0)             
+       scalar tlm = twice(lambda(0));      // 2*lambda(l=0)             
       const    scalar Dtl = 8*AL;                  // 2*(lambda(l+dl)-lambda(l))
       const    scalar xi2 = xi+xi;                 // 2*xi                      
       for(int l=0,ln=L1(P);                        // LOOP l=0...L,1            
 	  l<L1(P);                                 //   l+1 runs to L           
 	  l+=2,ln+=2,tlm+=Dtl) {                   //   increment stuff         
 	e(P,ln) = tlm * xi * e(P,l);               //   P(1,l) = 2*lam*xi*P(0,l)
-	register scalar tlmn2xi = (tlm+2)*xi;      //   2*(lam+n)*xi            
-	register scalar tlm1n   = tlm;             //   2*lam+n-1               
+	 scalar tlmn2xi = (tlm+2)*xi;      //   2*(lam+n)*xi            
+	 scalar tlm1n   = tlm;             //   2*lam+n-1               
 	for(int n1= 2,                             //   LOOP n+1=2...N          
 	      im  = l,                             //     i(n-1,l)              
 	      i   = im+L1(P),                      //     i(n  ,l)              
@@ -1056,7 +1056,7 @@ namespace {
 	e(D,lp) = fi*e(D,l) + dfi*e(P,l);          //   D(0,l+2) = dP(0,l+2)/dr 
       }                                            // END LOOP(l)               
       if(N1(P)==1) return;                         // no terms n>0 --> DONE     
-      register scalar tlm  = twice(lambda(0));     // 2*lambda(l=0)             
+       scalar tlm  = twice(lambda(0));     // 2*lambda(l=0)             
       const    scalar Dtl  = 8*AL;                 // 2*(lambda(l+dl)-lambda(l))
       const    scalar xi2  = xi+xi;                // 2*xi                      
       const    scalar dxi2 = dxi+dxi;              // d(2*xi)/dr                
@@ -1065,9 +1065,9 @@ namespace {
 	  l+=2,ln+=2,tlm+=Dtl) {                   //   increment stuff         
 	e(P,ln) = tlm* xi*e(P,l);                  //   P(1,l) = 2*lam*xi*P(0,l)
 	e(D,ln) = tlm*(xi*e(D,l)+dxi*e(P,l));      //   D(1,l) = dP(1,l)/dr     
-	register scalar tlmn2xi  = (tlm+2)*xi;     //   2*(lam+n)*xi            
-	register scalar dtlmn2xi = (tlm+2)*dxi;    //   d(2*(lam+n)*xi)/dr      
-	register scalar tlm1n    = tlm;            //   2*lam+n-1               
+	 scalar tlmn2xi  = (tlm+2)*xi;     //   2*(lam+n)*xi            
+	 scalar dtlmn2xi = (tlm+2)*dxi;    //   d(2*(lam+n)*xi)/dr      
+	 scalar tlm1n    = tlm;            //   2*lam+n-1               
 	for(int n1= 2,                             //   LOOP n+1=2...N          
 	      im  = l,                             //     i(n-1,l)              
 	      i   = im+L1(P),                      //     i(n  ,l)              
@@ -1134,7 +1134,7 @@ namespace {
     //--------------------------------------------------------------------------
 #if 0 // not used
     static scalar Dot(YlmRec const&A, YlmRec const&B) {
-      register scalar x=0.;
+       scalar x=0.;
       for(int l=0,i=0; l<L1(A); l+=2,i+=4*l-2) {
 	x += e(A,i) * e(B,i);
 	for(int m=2; m<=l; m+=2)
@@ -1149,7 +1149,7 @@ namespace {
 #endif
     //--------------------------------------------------------------------------
     static scalar Dot(Anlm const&A, Anlm const&B) {
-      register scalar x=0.;
+       scalar x=0.;
       for(int n=0,j=0; n!=N1(A); ++n,j+=L1Q(A))
 	for(int l=0; l<L1(A); l+=2)
 	  for(int m=0,i=j+l*l+l; m<=l; m+=2,i+=2)
@@ -1167,7 +1167,7 @@ namespace {
 	const scalar*Pi = Pn;
 	const scalar*Yl = p(Y);
 	for(int l=0; l<L1(A); l+=2,Al+=4*l-2,Pi+=2,Yl+=4*l-2) {
-	  register scalar y=0;
+	   scalar y=0;
 	  for(int m=0; m<=l; m+=2)
 	    y += (m==0)? Al[m]*Yl[m] : twice(Al[m]*Yl[m]);
 	  x += *Pi * y;
@@ -1195,7 +1195,7 @@ namespace {
 	const scalar*Ql = p(Q);
 	for(int l=0; l<L1(A);
 	    l+=2,Al+=4*l-2,Pi+=2,Ri+=2,Yl+=4*l-2,Tl+=4*l-2,Ql+=4*l-2) {
-	  register scalar y=0,yt=0,yp=0;
+	   scalar y=0,yt=0,yp=0;
 	  for(int m=0; m<=l; m+=2)
 	    if(m==0) {
 	      y  += Al[m] * Yl[m];
@@ -1220,8 +1220,8 @@ namespace {
     static void SetYlm(YlmRec&Y,
 		       scalar ct, scalar st, scalar cp, scalar sp) {
       AUX<PotExp::reflexion>::SetPlm(Y,ct,st);     // set Plm(theta)            
-      register scalar _Cp=1.,Cp;                   // cas( m*phi)               
-      register scalar _Cm=1.,Cm;                   // cas(-m*phi)               
+       scalar _Cp=1.,Cp;                   // cas( m*phi)               
+       scalar _Cm=1.,Cm;                   // cas(-m*phi)               
       const scalar cc=cp*cp-sp*sp, ss=2*cp*sp;
       for(int m=2; m<L1(Y); m+=2) {                // LOOP m=2...L,2            
 	Cp = cc * _Cp + ss * _Cm;                  //   cas[ m) := cas( m*phi)  
@@ -1243,8 +1243,8 @@ namespace {
     static void SetYlm(YlmRec&Y, YlmRec&T, YlmRec&P,
 		       scalar ct, scalar st, scalar cp, scalar sp) {
       AUX<PotExp::reflexion>::SetPlm(Y,T,ct,st);   // set Plm(the), dPlm/dthe   
-      register scalar _Cp=1.,Cp;                   // cas( m*phi)               
-      register scalar _Cm=1.,Cm;                   // cas(-m*phi)               
+       scalar _Cp=1.,Cp;                   // cas( m*phi)               
+       scalar _Cm=1.,Cm;                   // cas(-m*phi)               
       const scalar cc=cp*cp-sp*sp, ss=2*cp*sp;
       for(int l=0; l<L1(Y); l+=2) e(P,l*(l+1))=0;  // dY(l,m=0)/dp=0            
       for(int m=2; m<L1(Y); m+=2) {                // LOOP m=2...L,2            
@@ -1317,7 +1317,7 @@ namespace {
     //--------------------------------------------------------------------------
 #if 0 // not used
     static scalar Dot(YlmRec const&A, YlmRec const&B) {
-      register scalar x=0.;
+       scalar x=0.;
       for(int l=0,i=0; l<L1(A); l+=2,i+=4*l-2)
 	x += e(A,i) * e(B,i);
       return x;
@@ -1329,7 +1329,7 @@ namespace {
 #endif
     //--------------------------------------------------------------------------
     static scalar Dot(Anlm const&A, Anlm const&B) {
-      register scalar x=0.;
+       scalar x=0.;
       for(int n=0,j=0; n!=N1(A); ++n,j+=L1Q(A))
 	for(int l=0,i=j; l<L1(A); l+=2, i+=4*l-2)
 	  x += e(A,i)*e(B,i);
@@ -1479,7 +1479,7 @@ namespace {
     }
     //--------------------------------------------------------------------------
     static scalar Dot(AnlRec const&A, AnlRec const&B) {
-      register scalar x=0;
+       scalar x=0;
       for(int n=0,i=0; n!=N1(A); ++n,i+=L1(A))
 	x += e(A,i)*e(B,i);
       return x;
@@ -1487,7 +1487,7 @@ namespace {
 #endif
     //--------------------------------------------------------------------------
     static scalar Dot(Anlm const&A, Anlm const&B) {
-      register scalar x=0;
+       scalar x=0;
       for(int n=0,i=0; n!=N1(A); ++n,i+=L1Q(A))
 	x += e(A,i)*e(B,i);
       return x;
@@ -1563,8 +1563,8 @@ namespace {
       const scalar tlm = twice(lambda(0));         // 2*lambda(l=0)             
       const scalar xi2 = xi+xi;                    // 2*xi                      
       e(P,L1(P)) = tlm * xi * e(P,0);              // P(1,0) = 2*lam*xi*P(0,0)  
-      register scalar tlmn2xi = (tlm+2)*xi;        // 2*(lam+n)*xi              
-      register scalar tlm1n   = tlm;               // 2*lam+n-1                 
+       scalar tlmn2xi = (tlm+2)*xi;        // 2*(lam+n)*xi              
+       scalar tlm1n   = tlm;               // 2*lam+n-1                 
       for(int n1= 2,                               // LOOP n+1=2...N            
 	    im  = 0,                               //   i(n-1,l)                
 	    i   = im+L1(P),                        //   i(n  ,l)                
@@ -1592,9 +1592,9 @@ namespace {
       const scalar dxi2 = dxi+dxi;                 // 2*dxi/dr                  
       e(P,L1(P)) = tlm* xi*e(P,0);                 // P(1,0) = 2*lam*xi*P(0,0)  
       e(D,L1(P)) = tlm*(xi*e(D,0)+dxi*e(P,0));     // D(1,0) = dP(1,0)/dr       
-      register scalar tlmn2xi  = (tlm+2)*xi;       // 2*(lam+n)*xi              
-      register scalar dtlmn2xi = (tlm+2)*dxi;      // 2*(lam+n)*dxi             
-      register scalar tlm1n    = tlm;              // 2*lam+n-1                 
+       scalar tlmn2xi  = (tlm+2)*xi;       // 2*(lam+n)*xi              
+       scalar dtlmn2xi = (tlm+2)*dxi;      // 2*(lam+n)*dxi             
+       scalar tlm1n    = tlm;              // 2*lam+n-1                 
       for(int n1= 2,                               // LOOP n+1=2...N            
 	    im  = 0,                               //   i(n-1,l)                
 	    i   = im+L1(P),                        //   i(n  ,l)                
@@ -1700,7 +1700,7 @@ namespace {
   template<typename X, typename Y>
   inline void Spherical(X&rd, X&ct, X&st, X&cp, X&sp,
 			vector<3,Y> const& x) {
-    register X
+     X
       A  = x[0]*x[0]+x[1]*x[1],                    // R^2= x^2 + y^2
       B  = sqrt(A);                                // R  = sqrt(x^2 + y^2)
     A   += x[2]*x[2];                              // r^2= x^2 + y^2 + z^2
@@ -1726,7 +1726,7 @@ namespace {
   template<typename X, typename Y>
   inline void Cartesian(vector<3,Y> &a, X rd, X ct, X st, X cp, X sp) {
     if(rd) {
-      register X ir = IR0/rd;
+       X ir = IR0/rd;
       a[1] *= ir;
       if(st) a[2] *= ir/st;
       else   a[2]  = Y(0);
@@ -1734,7 +1734,7 @@ namespace {
       a[1] = Y(0);
       a[2] = Y(0);
     }
-    register Y
+     Y
       am = a[0] * st + a[1] * ct,                  // am = ar*st + at*ct        
       az = a[0] * ct - a[1] * st;                  // az = ar*ct - at*st        
     a[0] = am   * cp - a[2] * sp;                  // ax = am*cp - ap*sp        
@@ -3063,12 +3063,12 @@ int main()
     for(int i=0; i!=4; ++i)
       X[4*n+i] = Y[i];
 
-  register clock_t cpu0;
+   clock_t cpu0;
 
   cpu0 = clock();
   for(int i=0; i!=N4; ++i)
     Spherical(S[i],X[i]);
-  register real t1 = (clock() - cpu0)/real(CLOCKS_PER_SEC);
+   real t1 = (clock() - cpu0)/real(CLOCKS_PER_SEC);
   for(int i=0; i!=N4; ++i) S1 += S[i];
   cout<<" PotExp::Spherical():\n"
       <<"   time      = "<<t1<<" sec\n"
@@ -3077,7 +3077,7 @@ int main()
   cpu0 = clock();
   for(int i=0; i!=N4; i+=4)
     Spherical4(S+i,X+i);
-  register real t2 = (clock() - cpu0)/real(CLOCKS_PER_SEC);
+   real t2 = (clock() - cpu0)/real(CLOCKS_PER_SEC);
   for(int i=0; i!=N4; ++i) S2 += S[i];
   cout<<" PotExp::Spherical4():\n"
       <<"   time      = "<<t2<<" sec\n"

--- a/usr/dehnen/falcON/src/public/lib/PotExp.cc
+++ b/usr/dehnen/falcON/src/public/lib/PotExp.cc
@@ -44,14 +44,7 @@ namespace {
   // types                                                                    //
   //                                                                          //
   //////////////////////////////////////////////////////////////////////////////
-#if   defined(WDutils_included_tupel_h)
-  using   falcON::tupel;
-
-#elif defined(WDutils_included_vector_h)
   using   WDutils::vector;
-#else
-# error neither utils/tupel.h nor utils/vector.h
-#endif
   using   falcON::fvec4;
   typedef PotExp::scalar   scalar;
   typedef PotExp::symmetry symmetry;

--- a/usr/dehnen/falcON/src/public/lib/PotExp.cc
+++ b/usr/dehnen/falcON/src/public/lib/PotExp.cc
@@ -46,7 +46,7 @@ namespace {
   //////////////////////////////////////////////////////////////////////////////
 #if   defined(WDutils_included_tupel_h)
   using   falcON::tupel;
-# define  vector tupel
+
 #elif defined(WDutils_included_vector_h)
   using   WDutils::vector;
 #else

--- a/usr/dehnen/falcON/src/public/lib/WD99disc.cc
+++ b/usr/dehnen/falcON/src/public/lib/WD99disc.cc
@@ -245,8 +245,8 @@ double WD99disc::PlanarOrbit::CashKarp(vect_d&W_, double dt, double eps)
   Ws += cs0*Kx0+cs2*Kx2+cs3*Kx3+cs4*Kx4+cs5*Kx5;
   W_ += c0*Kx0+c2*Kx2+c3*Kx3+c5*Kx5;
   
-  double h = maxnorm(W_-Ws);
-  if(h>1.e-19*maxnorm(W_) ) h = pow(eps/h,0.2);
+  double h = WDutils::max_abs(W_-Ws);
+  if(h>1.e-19*WDutils::max_abs(W_) ) h = pow(eps/h,0.2);
   else                      h = 1.e3;
   return min(h,2.);
 }

--- a/usr/dehnen/falcON/src/public/lib/WD99disc.cc
+++ b/usr/dehnen/falcON/src/public/lib/WD99disc.cc
@@ -212,7 +212,7 @@ PlanarOrbit::sample(Random const&RNG,         // I: random
 void WD99disc::PlanarOrbit::CashKarpStep(vect_d&W_, double  eps)
 {
   vect_d W0=W_;
-  register double h;
+   double h;
   do {
     h   = CashKarp(W0,dT,eps);
     dT *= h;
@@ -263,7 +263,7 @@ vect_d WD99disc::PlanarOrbit::Dt(const vect_d&w)
 //------------------------------------------------------------------------------
 void WD99disc::PlanarOrbit::step_back_to_R_equal(double R, vect_d&y)
 {
-  register double dR=R-y[1];
+   double dR=R-y[1];
   vect_d dy, y0(y);
   y+=( dy=dR*DR(y0)        )/6.;
   y+=( dy=dR*DR(y0+0.5*dy) )/3.;
@@ -570,7 +570,7 @@ void WD99disc::sample( bodies const&B,           // I/O: bodies to sample
 	
 	Bi.mass() = mpart;                         //     set mass           
 	Mcum += mpart;                             //     cumulate total mass
-	register double cph=cos(ph), sph=sin(ph);  //
+	 double cph=cos(ph), sph=sin(ph);  //
 	Bi.pos()[0] = R * cph;                     //     x=r*sin(th)*cos(ph)   
 	Bi.pos()[1] = R * sph;                     //     y=r*sin(th)*sin(ph)   
 	Bi.pos()[2] = z;                           //     z=r*cos(th)   
@@ -666,7 +666,7 @@ void WD99disc::coldsample(bodies const&B,            // I/O: bodies to sample
 	
 	  Bi.mass() = mpart;                          //     set mass           
 	  Mcum += mpart;                              //     cumulate total mass
-	  register double cph=cos(phi), sph=sin(phi); //
+	   double cph=cos(phi), sph=sin(phi); //
 	  Bi.pos()[0] = Re * cph;                     //    x=r*sin(th)*cos(ph) 
 	  Bi.pos()[1] = Re * sph;                     //    y=r*sin(th)*sin(ph) 
 	  Bi.pos()[2] = z;                            //    z=r*cos(th)   

--- a/usr/dehnen/falcON/src/public/lib/basic.cc
+++ b/usr/dehnen/falcON/src/public/lib/basic.cc
@@ -170,11 +170,11 @@ void falcON::report::close_file()
 falcON::report::report(const char* fmt, ... )
 {
   if(REPORT && REPORT->STREAM) {
-    register clock_t NOW = clock();
+     clock_t NOW = clock();
     REPORT->SECONDS += (NOW - REPORT->LAST)/double(CLOCKS_PER_SEC);
     REPORT->LAST = NOW;
     fprintf(REPORT->STREAM,"%10.2f: ",REPORT->SECONDS);
-    for(register int l=0; l!=REPORT->LEVEL; ++l) fprintf(REPORT->STREAM,"  ");
+    for( int l=0; l!=REPORT->LEVEL; ++l) fprintf(REPORT->STREAM,"  ");
     fprintf(REPORT->STREAM,"begin: ");
     va_list  ap;
     va_start(ap,fmt);
@@ -195,11 +195,11 @@ falcON::report::report(const char* fmt, ... )
 void falcON::report::info(const char* fmt, ... )
 {
   if(REPORT && REPORT->STREAM) {
-    register clock_t NOW = clock();
+     clock_t NOW = clock();
     REPORT->SECONDS += (NOW - REPORT->LAST)/double(CLOCKS_PER_SEC);
     REPORT->LAST = NOW;
     fprintf(REPORT->STREAM,"%10.2f: ",REPORT->SECONDS);
-    for(register int l=0; l!=REPORT->LEVEL; ++l) fprintf(REPORT->STREAM,"  ");
+    for( int l=0; l!=REPORT->LEVEL; ++l) fprintf(REPORT->STREAM,"  ");
     fprintf(REPORT->STREAM,"doing: ");
     va_list  ap;
     va_start(ap,fmt);
@@ -219,12 +219,12 @@ void falcON::report::info(const char* fmt, ... )
 falcON::report::~report()
 {
   if(REPORT && REPORT->STREAM) {
-    register clock_t NOW = clock();
+     clock_t NOW = clock();
     REPORT->SECONDS += (NOW - REPORT->LAST)/double(CLOCKS_PER_SEC);
     REPORT->LAST = NOW;
     --(REPORT->LEVEL);
     fprintf(REPORT->STREAM,"%10.2f: ",REPORT->SECONDS);
-    for(register int l=0; l!=REPORT->LEVEL; ++l) fprintf(REPORT->STREAM,"  ");
+    for( int l=0; l!=REPORT->LEVEL; ++l) fprintf(REPORT->STREAM,"  ");
     fprintf(REPORT->STREAM,"done\n");
     fflush(REPORT->STREAM);
     fpos_t here;

--- a/usr/dehnen/falcON/src/public/lib/body.cc
+++ b/usr/dehnen/falcON/src/public/lib/body.cc
@@ -1761,7 +1761,7 @@ namespace {
     /// \param  rec  size of Fortran record header (must be 4 or 8)
     /// \param  swap (output) need byte-swap?
     bool Read(input& in, unsigned rec, bool& swap)
-      throw(falcON::exception);
+      noexcept(false);
     /// check whether two GadgetHeaders could possibly come from different data
     /// files for the same snapshot
     bool mismatch(GadgetHeader const&H) const;
@@ -1785,7 +1785,7 @@ namespace {
   }
   //
   bool GadgetHeader::Read(input& in, unsigned rec, bool& swap)
-    throw(falcON::exception)
+    noexcept(false)
   {
     swap = 0;
     // read record header and determine swapping necessity

--- a/usr/dehnen/falcON/src/public/lib/bodyfunc.cc
+++ b/usr/dehnen/falcON/src/public/lib/bodyfunc.cc
@@ -132,7 +132,7 @@ namespace {
   }
   //////////////////////////////////////////////////////////////////////////////
   inline fieldset get_type_and_need(char&type, const char*name, const char*expr)
-    throw(BfErr)
+    noexcept(false)
   {
     // finds function name and determines type
     bt_pter Type = (bt_pter)findfn(name);
@@ -150,7 +150,7 @@ namespace {
   // "-DfalcON_DOUBLE") as are used to compile this file, since otherwise 
   // loading the running the generated code will result in rubbish (at best).
   void compile(const char*flags, const char*fname)
-    throw(BfErr) {
+    noexcept(false) {
     // compiles a falcON C++ program in fname using compiler flags              
     const char* falcON_path = falcON::directory();
     if(falcON_path == 0) throw BfErr("cannot locate falcON directory");
@@ -238,7 +238,7 @@ namespace {
 			         char*&to,         // O:     output             
 			   const char* toUP,       // I:     end for output     
 			   int       & npar)       // I/O: # parameters         
-    throw(ParseErr)
+    noexcept(false)
   {
     if(*in==ParInd) {                              // IF parameter indicator    
       ++in;                                        //   read indicator          
@@ -260,7 +260,7 @@ namespace {
 			 char*      &to,           // O:     output             
 			 const char* toUP,         // I:     end for output     
 			 int        &npar)         // I/O: # parameters         
-    throw(ParseErr)
+    noexcept(false)
   {
     try {
       while(*in)
@@ -284,7 +284,7 @@ namespace {
     // - set fullfile = $FALCONLIB/subdir/file                                  
     // - make sure that directory $FALCONLIB/subdir/ exists                     
     BF_database(const char*subdir,
-		const char*file) throw(DataBaseErr) : locked(0)
+		const char*file) noexcept(false) : locked(0)
     {
       // get falcON library directory
       const char*falcONlib = falcON::libdir();
@@ -384,7 +384,7 @@ namespace {
     // - otherwise:                 - copy to backup file and lock it           
     //                              - loop database, count functions            
     //                              - return count                              
-    int counter() throw(DataBaseErr) {             // R: valid function counter 
+    int counter() noexcept(false) {             // R: valid function counter 
       char cmmd[STR_LENGTH];
       // check for existence of backup-file
       SNprintf(cmmd,STR_LENGTH,"ls %s.bak > /dev/null 2>&1",fullfile);
@@ -442,7 +442,7 @@ namespace {
 	     char     const&type,                  // I: function type          
 	     int      const&npar,                  // I: number of parameters   
 	     fieldset const&need)                  // I: function need          
-      throw(DataBaseErr)
+      noexcept(false)
     {
       if(!locked) throw DataBaseErr("not locked, cannot put()");
       char cmmd[STR_LENGTH];
@@ -485,7 +485,7 @@ namespace {
   void get_type(char       &type,            // O: return type
 		fieldset   &need,            // O: body data required 
 		const char *expr)            // I: C-expression encoded in func 
-    throw(BfErr)
+    noexcept(false)
   {
     // P   preparations
     if (!havesyms) {
@@ -557,7 +557,7 @@ namespace {
 		    const char*ftype,       // I: function return type          
 		    const char*fname,       // I: file base name                
 		    const char*funcn)       //[I: function name]                
-    throw(BfErr)
+    noexcept(false)
   {
     // P   preparations
     if (!havesyms) {
@@ -660,7 +660,7 @@ namespace {
   //----------------------------------------------------------------------------
   bool ParseExpr(                                  // R: finished with '}' ?    
 		 const char*&expr)                 // bodiesfunc expression     
-    throw(ParseErr)
+    noexcept(false)
   {
     int we    = sub++;                             // remember sexpr counter    
     scond[we] = 0;                                 // reset subconditional      
@@ -716,7 +716,7 @@ namespace {
     return false;                                  // end of expr               
   } // ParseExpr
   //----------------------------------------------------------------------------
-  inline void parse_expr(const char*expr) throw(ParseErr)
+  inline void parse_expr(const char*expr) noexcept(false)
   {
     sub = 0;
     par = 0;
@@ -749,7 +749,7 @@ namespace {
   // needs.                                                                   //
   //                                                                          //
   //////////////////////////////////////////////////////////////////////////////
-  void get_types(fieldset&need) throw(BfErr) {
+  void get_types(fieldset&need) noexcept(false) {
     // 0 preparations
     if (!havesyms) {
       localsymbols();
@@ -831,7 +831,7 @@ namespace {
   // The files "/tmp/name.cc" and "/tmp/name.log" will NOT be deleted         //
   //                                                                          //
   //////////////////////////////////////////////////////////////////////////////
-  inline void make_mean(std::ostream&file, int s) throw(ParseErr) {
+  inline void make_mean(std::ostream&file, int s) noexcept(false) {
     if(stype[s] == 'b')
       throw ParseErr("operator 'Mean' must have non-boolean expression");
     const char *space = scond[s]? "      " : "    ";
@@ -854,7 +854,7 @@ namespace {
 	  <<"    return _X;\n";
   }
   //----------------------------------------------------------------------------
-  inline void make_mmean(std::ostream&file, int s) throw(ParseErr) {
+  inline void make_mmean(std::ostream&file, int s) noexcept(false) {
     if(stype[s] == 'b')
       throw ParseErr("operator 'Mmean' must have non-boolean expression");
     const char *space = scond[s]? "      " : "    ";
@@ -876,7 +876,7 @@ namespace {
 	  <<"    return _X;\n";
   }
   //----------------------------------------------------------------------------
-  inline void make_sum(std::ostream&file, int s) throw(ParseErr) {
+  inline void make_sum(std::ostream&file, int s) noexcept(false) {
     if(stype[s] == 'b')
       throw ParseErr("operator 'Sum' must have non-boolean expression");
     file  <<"    // encoding \"Sum{"<<sexpr[s];
@@ -892,7 +892,7 @@ namespace {
 	  <<"    return _X;\n";
   }
   //----------------------------------------------------------------------------
-  inline void make_max(std::ostream&file, int s) throw(ParseErr) {
+  inline void make_max(std::ostream&file, int s) noexcept(false) {
     if(stype[s] == 'b')
       throw ParseErr("operator 'Max' must have non-boolean expression");
     const char *space = scond[s]? "      " : "    ";
@@ -921,7 +921,7 @@ namespace {
 	  <<"    return _X;\n";
   }
   //----------------------------------------------------------------------------
-  inline void make_min(std::ostream&file, int s) throw(ParseErr) {
+  inline void make_min(std::ostream&file, int s) noexcept(false) {
     if(stype[s] == 'b')
       throw ParseErr("operator 'Min' must have non-boolean expression");
     const char *space = scond[s]? "      " : "    ";
@@ -976,7 +976,7 @@ namespace {
 	  <<"    return false;\n";
   }
   //----------------------------------------------------------------------------
-  inline void make_num(std::ostream&file, int s) throw(ParseErr) {
+  inline void make_num(std::ostream&file, int s) noexcept(false) {
     if(scond[s]==0 || scond[s][0]==0)
       throw ParseErr("empty condition for operator 'Num'");
     file  <<"    // encoding \"Num{"<<scond[s]<<"}\"\n"
@@ -986,7 +986,7 @@ namespace {
 	  <<"    return _N;\n";
   }
   //----------------------------------------------------------------------------
-  void make_sub(std::ostream&file, int s) throw(ParseErr) {
+  void make_sub(std::ostream&file, int s) noexcept(false) {
     file<<"\n  inline "<<TypeName(stype[s])<<' '<<sname[s]<<'F'
 	<<"(bodies const&B, double t, const real*_P) {\n";
     switch(soper[s]) {
@@ -1007,7 +1007,7 @@ namespace {
   Bf_pter make_func(                        // R: bodiesfunc                    
 		    const char*fname,       // I: file base name                
 		    const char*funcn)       //[I: function name]                
-    throw (BfErr)
+    noexcept(false)
   {
     // P   preparations
     if (!havesyms) {
@@ -1079,7 +1079,7 @@ namespace {
 //
 // implementing falcON::bodyfunc::bodyfunc(const char*)
 //
-bodyfunc::bodyfunc(const char*oexpr) throw(falcON::exception)
+bodyfunc::bodyfunc(const char*oexpr) noexcept(false)
   : FUNC(0), TYPE(0), NPAR(0), NEED(fieldset::empty), EXPR(0)
 {
   if(oexpr == 0 || *oexpr == 0) return;
@@ -1186,7 +1186,7 @@ bool bodyfunc::print_db(std::ostream&out)
 //                                                                              
 ////////////////////////////////////////////////////////////////////////////////
 falcON::Bodyfunc::Bodyfunc(const char*expr, const char*pars)
-  throw(falcON::exception)
+  noexcept(false)
   : bodyfunc(expr), PARS(0)
 {
   if(is_empty()) return;
@@ -1214,7 +1214,7 @@ falcON::Bodyfunc::Bodyfunc(const char*expr, const char*pars)
 }
 //
 void falcON::Bodyfunc::getpars(const real*pars, int _npar)
-  throw(falcON::exception)
+  noexcept(false)
 {
   if(NPAR) {
     if(_npar == 0 || pars == 0)
@@ -1265,7 +1265,7 @@ namespace {
 }
 //
 template<typename T>
-void falcON::BodyFunc<T>::checktype() const throw(falcON::exception)
+void falcON::BodyFunc<T>::checktype() const noexcept(false)
 {
   if(is_empty()) return;
   if(TYPE != bf_type<T>::type )
@@ -1283,18 +1283,18 @@ template class falcON::BodyFunc<vect>;
 //                                                                              
 ////////////////////////////////////////////////////////////////////////////////
 falcON::BodyFilter::BodyFilter(const char*expr, const char*pars)
-  throw(falcON::exception)
+  noexcept(false)
   : BodyFunc<bool>(expr,pars), TIME(0.) {}
 ////////////////////////////////////////////////////////////////////////////////
 falcON::BodyFilter::BodyFilter(const char*expr, const real*pars, int _npar)
-  throw(falcON::exception)
+  noexcept(false)
   : BodyFunc<bool>(expr,pars,_npar), TIME(0.) {}
 ////////////////////////////////////////////////////////////////////////////////
 //                                                                            //
 // implementing falcON::bodiesfunc::bodiesfunc()                              //
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
-bodiesfunc::bodiesfunc(const char*oexpr) throw(falcON::exception)
+bodiesfunc::bodiesfunc(const char*oexpr) noexcept(false)
 {
   // 0 eliminate white space from expression
   shrink(nexpr,MAX_LENGTH_EXPR,oexpr);
@@ -1422,7 +1422,7 @@ namespace {
 		      const char*ftype,     // I: function return type          
 		      const char*fname,     // I: file base name                
 		      const char*funcn)     //[I: function name]                
-    throw(BfErr)
+    noexcept(false)
   {
     // P   preparations
     if (!havesyms) {

--- a/usr/dehnen/falcON/src/public/lib/gamma.cc
+++ b/usr/dehnen/falcON/src/public/lib/gamma.cc
@@ -39,7 +39,7 @@ namespace {
   //----------------------------------------------------------------------------
   inline void subyceg(double y, double&f, double&df)
   { 
-    register double yg1 = pow(y,g1);
+     double yg1 = pow(y,g1);
     f  = 0.5*y*yg1*(g2*y-g4) + 1. - eg2;
     df = 0.5*g2*(g3*y-g4)*yg1;
   }
@@ -68,7 +68,7 @@ double DehnenModel::YcofE(double E) const
 namespace {
   inline void subyclg(double y, double&f, double&df)
   { 
-    register double yg3 = pow(y,g3);
+     double yg3 = pow(y,g3);
     f  = (yg3+lq)*y-lq;
     df = g4*yg3+lq;
   }
@@ -92,13 +92,13 @@ double DehnenModel::SigIsoQ(double x) const
 {
   if(g>2. && x==0.)
     falcON_Error("DehnenModel: SigIsotropicSquared() diverges at x=0");
-  register double x1=x+1;
+   double x1=x+1;
   if(g==0.)  return (6.*x+1.)/(30.*x1*x1);
-  register double y=x/x1;
+   double y=x/x1;
   if(g==0.5) return 0.2*sqrt(y)/x1;
   if(x>=10.) { // use formula (9) of Tremaine et al. (1994)
     double xi=1./x, al=2.*g-6., fac=1., xi5=power<5>(xi), sum=0.2*xi5;
-    for(register int k=1; k<10; k++)
+    for( int k=1; k<10; k++)
       {
 	al  -= 1.;
 	fac *= al/double(k);
@@ -114,13 +114,13 @@ double DehnenModel::SigIsoQ(double x) const
       * (((-1./3.*y+2.)*y-6.)*y+1./y+10./3.+4.*log(y));
   if(g==2.) {
     if(x==0.) return 0.5;
-    register double y2 = y * y;
+     double y2 = y * y;
     return y2 * power<4>(x1) * (0.5/y2*(1.-y2)*((y-8.)*y+1)-6.*log(y));
   }
   if(g==2.5)
     return power<4>(x1) / sqrt(y)
       * ((((-y+(4.*log(y)-10./3.))*y+6.)*y-2.)*y+1./3.);
-  register double g2n=g2-g, ygn=pow(y,g2n), sum;
+   double g2n=g2-g, ygn=pow(y,g2n), sum;
   sum = (1.-ygn) / g2n;
   sum-= 4.*(1.-(ygn*=y)) / (g2n+=1.);
   sum+= 6.*(1.-(ygn*=y)) / (g2n+=1.);
@@ -144,7 +144,7 @@ namespace {
   //----------------------------------------------------------------------------
   inline double subsur(double t)
   { 
-    register double tq = t*t;
+     double tq = t*t;
     return pow(s+tq,g1) * power<2>(1-tq) / sqrt(ts+sa*tq);
   }
 }
@@ -163,7 +163,7 @@ double DehnenModel::SurfaceDensity(double R) const
 namespace {
   inline double subdsu(double t)
   { 
-    register double tq = t*t;
+     double tq = t*t;
     return (g4*tq + fsg) * power<4>(1.-tq) / (pow(s+tq,ga) * sqrt(ts+sa*tq));
   }
 }
@@ -183,7 +183,7 @@ double DehnenModel::DSurfaceDensityDR(double R) const
 namespace {
   inline double subcsd(double t)
   {
-    register double tq = t*t;
+     double tq = t*t;
     return pow(s+tq,g1) * tq * sqrt(ts+sa*tq);
   }
 }
@@ -223,7 +223,7 @@ double DehnenModel::EffectiveRadius() const
 namespace {
   inline double subsip(double t)
   {
-    register double tq = t*t;
+     double tq = t*t;
     return pow(s+tq,g12) * power<3>(1-tq) * tq * sqrt(ts+sa*tq);
   }
 }
@@ -246,7 +246,7 @@ double DehnenModel::SigIsotropicProj(double R) const
 namespace {
   inline double subscp(double t)
   {
-    register double tq = t*t;
+     double tq = t*t;
     return pow(s+tq,g12) * power<5>(1-tq) / sqrt(ts+sa*tq);
   }
 }
@@ -283,7 +283,7 @@ namespace {
   //----------------------------------------------------------------------------
   inline double subfei(double t)
   {
-    register double y = subyofp(e*(1-t*t));
+     double y = subyofp(e*(1-t*t));
     return power<2>(1-y) * (Ag+y*(Bg+Cg*y)) / pow(y,Pg);
   }
 }
@@ -304,7 +304,7 @@ double DehnenModel::Fsub(double E, double _G) const
   if(dg<0.)
     falcON_Error("DehnenModel: G > gamma in F(E,G)");
   if(g==0. && dg==0.) {
-    register double e1=sqrt(e+e), e2=1-e-e, e3=sqrt(e2);
+     double e1=sqrt(e+e), e2=1-e-e, e3=sqrt(e2);
     return 1.5/Pi3*(e1*(2+1./e2)-3.*std::log((1+e1)/e3));
   }
   ::g2 = g2;
@@ -351,16 +351,16 @@ namespace {
   inline double sub_geA(double t)
   {
     // for gamma < 2
-    register double tq = t*t;
-    register double z  = eg2-tq;
+     double tq = t*t;
+     double z  = eg2-tq;
     if(z<=0. || z>=1.) return 0;
     return pow(z,g1) * tq/power<4>(1-pow(z,ig2));
   }
   inline double sub_geB(double t)
   {
     // for gamma > 2
-    register double tq = t*t;
-    register double y  = pow(eg2*(1-tq),-ig2);
+     double tq = t*t;
+     double y  = pow(eg2*(1-tq),-ig2);
     if(y<=0. || y>=1.) return 0;
     return pow(y,g1) * tq/power<4>(1-y);
   }
@@ -368,8 +368,8 @@ namespace {
   {
     // for gamma = 2
     if(z<=0. || z>=1.) return 0.;
-    register double z1 = 1-z;
-    register double y  = exp(-e-square(z/z1));
+     double z1 = 1-z;
+     double y  = exp(-e-square(z/z1));
     return y*square(y*z/square(z1*(1-y)));
   }
 }

--- a/usr/dehnen/falcON/src/public/lib/kernel.cc
+++ b/usr/dehnen/falcON/src/public/lib/kernel.cc
@@ -182,8 +182,8 @@ real GravKernBase::Psi(kern_type k, real Xq, real Eq)
 #define P1(MUM)					\
   x  = one/(Rq+EQ);				\
   D0 = MUM*sqrt(x);				\
-  register real D1 = D0*x;			\
-  register real hq = half*EQ;			\
+   real D1 = D0*x;			\
+   real hq = half*EQ;			\
   D0+= hq*D1;					\
   D1+= hq*3*D1*x;				\
   R *= D1;
@@ -191,8 +191,8 @@ real GravKernBase::Psi(kern_type k, real Xq, real Eq)
 #define P2(MUM)						\
   x  = one/(Rq+EQ);					\
   D0 = MUM*sqrt(x);					\
-  register real D1 = D0*x, D2= 3*D1*x, D3= 5*D2*x;	\
-  register real hq = half*EQ;				\
+   real D1 = D0*x, D2= 3*D1*x, D3= 5*D2*x;	\
+   real hq = half*EQ;				\
   D0+= hq*(D1+hq*D2);					\
   D1+= hq*(D2+hq*D3);					\
   R *= D1;
@@ -200,9 +200,9 @@ real GravKernBase::Psi(kern_type k, real Xq, real Eq)
 #define P3(MUM)							\
   x  = one/(Rq+EQ);						\
   D0 = MUM*sqrt(x);						\
-  register real D1 = D0*x, D2= 3*D1*x, D3= 5*D2*x, D4= 7*D3*x;	\
-  register real hq = half*EQ;					\
-  register real qq = half*hq;					\
+   real D1 = D0*x, D2= 3*D1*x, D3= 5*D2*x, D4= 7*D3*x;	\
+   real hq = half*EQ;					\
+   real qq = half*hq;					\
   D0+= ((hq*D3+D2)*qq+D1)*hq;					\
   D1+= ((hq*D4+D3)*qq+D2)*hq;					\
   R *= D1;
@@ -310,7 +310,7 @@ void GravKernAll::single(leaf_iter const &A, leaf_iter const&B) const
 //                                                                              
 //==============================================================================
 # define DSINGL_P0_G				\
-  register real					\
+   real					\
   XX  = one/D1;					\
   D0 *= sqrt(XX);				\
   D1  = XX * D0;
@@ -318,7 +318,7 @@ void GravKernAll::single(leaf_iter const &A, leaf_iter const&B) const
   DSINGL_P0_G
 //------------------------------------------------------------------------------
 # define DSINGL_P1_G				\
-  register real					\
+   real					\
   XX  = one/D1;					\
   D0 *= sqrt(XX);				\
   D1  = XX * D0;				\
@@ -330,11 +330,11 @@ void GravKernAll::single(leaf_iter const &A, leaf_iter const&B) const
   DSINGL_P1_G
 //------------------------------------------------------------------------------
 # define DSINGL_P2_G				\
-  register real					\
+   real					\
   XX  = one/D1;					\
   D0 *= sqrt(XX);				\
   D1  = XX * D0;				\
-  register real					\
+   real					\
   D2  = 3 * XX * D1;				\
   XX *= 5 * D2;           /* XX == T3 */	\
   D0 += HQ*(D1+HQ*D2);				\
@@ -344,13 +344,13 @@ void GravKernAll::single(leaf_iter const &A, leaf_iter const&B) const
   DSINGL_P2_G
 //------------------------------------------------------------------------------
 # define DSINGL_P3_G				\
-  register real					\
+   real					\
   XX  = one/D1;					\
   D0 *= sqrt(XX);				\
   D1  =     XX * D0;				\
-  register real					\
+   real					\
   D2  = 3 * XX * D1;				\
-  register real					\
+   real					\
   D3  = 5 * XX * D2;				\
   XX *= 7 * D3;           /* XX == T4 */	\
   D0 += HQ*(D1+QQ*(D2+HQ*D3));			\
@@ -420,14 +420,14 @@ void GravKernAll::single(leaf_iter const &A, leaf_iter const&B) const
   }
 //------------------------------------------------------------------------------
 #define GRAV_ALL(LOAD,DSINGL,PUT)		\
-for(register leaf_iter B=B0; B!=BN; ++B) {	\
+for( leaf_iter B=B0; B!=BN; ++B) {	\
   LOAD						\
   DSINGL					\
   PUT						\
 } 
 //------------------------------------------------------------------------------
 #define GRAV_FEW(LOAD,DSINGL)			\
-for(register leaf_iter B=B0; B!=BN; ++B)	\
+for( leaf_iter B=B0; B!=BN; ++B)	\
   if(is_active(B)) {				\
     LOAD					\
     DSINGL					\
@@ -438,14 +438,14 @@ for(register leaf_iter B=B0; B!=BN; ++B)	\
   const    real      M0=mass(A);		\
   const    vect      X0=cofm(A);		\
            vect      dR;			\
-  register real      D0,D1;
+   real      D0,D1;
 //------------------------------------------------------------------------------
 #define START_I					\
   const    real      E0=eph(A);			\
   const    real      M0=mass(A);		\
   const    vect      X0=cofm(A);		\
            vect      dR;			\
-  register real      D0,D1;
+   real      D0,D1;
 //==============================================================================
 // now defining auxiliary inline functions for the computation of  N            
 // interactions. There are the following 10 cases:                              
@@ -457,17 +457,17 @@ namespace {
   //////////////////////////////////////////////////////////////////////////////
 #define DIRECT(START,LOAD,DSINGL)				\
     static void many_YA(ARGS) {					\
-      START; register real P0(zero); vect F0(zero);		\
+      START;  real P0(zero); vect F0(zero);		\
       GRAV_ALL(LOAD,DSINGL,PUT_BOTH)				\
       A->pot()+=P0;  A->acc()+=F0;				\
     }								\
     static void many_YS(ARGS) {					\
-      START; register real P0(zero); vect F0(zero);		\
+      START;  real P0(zero); vect F0(zero);		\
       GRAV_ALL(LOAD,DSINGL,PUT_SOME)				\
       A->pot()+=P0; A->acc()+=F0;				\
     }								\
     static void many_YN(ARGS) {					\
-      START; register real P0(zero); vect F0(zero);		\
+      START;  real P0(zero); vect F0(zero);		\
       GRAV_ALL(LOAD,DSINGL,PUT_LEFT)				\
       A->pot()+=P0; A->acc()+=F0;				\
     }								\

--- a/usr/dehnen/falcON/src/public/lib/king.cc
+++ b/usr/dehnen/falcON/src/public/lib/king.cc
@@ -41,7 +41,7 @@ namespace {
   {
     const double f1  =1.1283791670955125739, f2=2./3.;  // sqrt(4/Pi)           
     if(Psi<=0.) return 0.;
-    register double sPsi=sqrt(Psi);
+     double sPsi=sqrt(Psi);
     return exp(Psi)*erf(sPsi) - f1*sPsi*(1+f2*Psi);
   }
   //--------------------------------------------------------------------------
@@ -150,8 +150,8 @@ void king_model::reset_scales_core(const double M, const double R0)
 //==============================================================================
 double king_model::rms_radius() const
 {
-  register double dM,y=0.;
-  for(register unsigned i=0,j=1; j!=N; ++i,++j) {
+   double dM,y=0.;
+  for( unsigned i=0,j=1; j!=N; ++i,++j) {
     dM  = m[j]-m[i];
     y  += (square(r[j])+square(r[i]))*dM;
   }
@@ -169,8 +169,8 @@ double king_model::half_mass_radius() const
 //==============================================================================
 double king_model::Etot() const
 {
-  register double dM, psi,e=0.;
-  for(register unsigned i=0,j=1; j!=N; ++i,++j) {
+   double dM, psi,e=0.;
+  for( unsigned i=0,j=1; j!=N; ++i,++j) {
     dM  = m[j]-m[i];
     psi = ps[j]+ps[i];
     e  += dM*psi;
@@ -191,7 +191,7 @@ void king_model::write_table(const char* file) const
   if(! open(table,file) )  return;
   table.setf(ios::left, ios::adjustfield);
   table<<"#        r     Phi(r)     rho(r)       M(r)\n";
-  for(register unsigned i=0; i<N; i++)
+  for( unsigned i=0; i<N; i++)
     table<<setw(10)<<setprecision(6)<<rscal*r[i]      <<" "  // r     
 	 <<setw(10)<<setprecision(6)<<Pscal*(P0-ps[i])<<" "  // Phi(r)
 	 <<setw(10)<<setprecision(6)<<rhscl*rh[i]     <<" "  // rho(r)
@@ -216,7 +216,7 @@ namespace {
     // its derivative p(v|r) = 4Pi f(v|r) v^2                                   
     const double sqh = 0.70710678118654752440,
                  sq2p= 0.79788456080286535588;     // sqrt(2/Pi)                
-    register double vq=v*v;
+     double vq=v*v;
     P = exp(psi)*erf(v*sqh)-sq2p*(vq*v/3.+v*exp(psi-0.5*vq)) - rhi;
     p = FPi * feps(psi-0.5*vq) * vq;
   }
@@ -225,7 +225,7 @@ namespace {
 double king_model::random(const double R1, const double R2,
 			  double &rad, double &vel) const {
   // 1. find radius from cumulative mass                                        
-  register double mi = R1*m[N-1];             // mass(<rad)                     
+   double mi = R1*m[N-1];             // mass(<rad)                     
   rad = polev(mi,m,r, N);                     // corresponding radius           
   // 2. find velocity from cumulative mass at given radius                      
   psi = polev(mi,m,ps,N);                     // psi(rad)                       
@@ -246,7 +246,7 @@ namespace {
   //----------------------------------------------------------------------------
   inline double sd_integrand(const double z)
   {
-    register double radius = sqrt(Rq+z*z);
+     double radius = sqrt(Rq+z*z);
     return (radius >= rt)? 0.0 : polev(radius,rad,rho,K);
   }
 }

--- a/usr/dehnen/falcON/src/public/lib/nbody.cc
+++ b/usr/dehnen/falcON/src/public/lib/nbody.cc
@@ -435,7 +435,7 @@ BlockStepCode::BlockStepCode(int      km,          // I: tau_max = 2^-kmax
 ////////////////////////////////////////////////////////////////////////////////
 namespace falcON {
   inline std::ostream& put_char(std::ostream&o, const char c, const int s) {
-    if(s>0) for(register int i=0; i<s; ++i) o<<c;
+    if(s>0) for( int i=0; i<s; ++i) o<<c;
     return o;
   }
 }
@@ -569,7 +569,7 @@ void ForceDiagGrav::diagnose_grav() const
   vect_d x(0.);
   if(snap_shot()->have(fieldbit::q)) {             // IF have external pot      
     LoopAllBodies(snap_shot(),b) {                 //   LOOP bodies             
-      register double mi = mass(b);                //     m                     
+       double mi = mass(b);                //     m                     
       m  += mi;                                    //     add: total mass       
       vin+= mi * pot(b);                           //     add: int pot energy   
       vex+= mi * pex(b);                           //     add: ext pot energy   
@@ -579,7 +579,7 @@ void ForceDiagGrav::diagnose_grav() const
     }                                              //   END LOOP                
   } else {                                         // ELSE: no external pot     
     LoopAllBodies(snap_shot(),b) {                 //   LOOP bodies             
-      register double mi = mass(b);                //     m                     
+       double mi = mass(b);                //     m                     
       m  += mi;                                    //     add: total mass       
       vin+= mi * pot(b);                           //     add: int pot energy   
       vect_d mx = mi * vect_d(pos(b));             //     m * x                 
@@ -629,7 +629,7 @@ void ForceDiagGrav::diagnose_vels() const falcON_THROWING
   double m(0.), k[Ndim][Ndim]={{0.}};
   vect_d v(0.), l(0.);
   LoopAllBodies(snap_shot(),b) {                   // LOOP bodies               
-    register double mi = mass(b);                  //   m                       
+     double mi = mass(b);                  //   m                       
     m  += mi;                                      //   add: total mass         
     vect_d mv = mi * vect_d(vel(b));               //   m * v                   
     AddTensor(k,mv,vel(b));                        //   add to K_ij             
@@ -670,7 +670,7 @@ void ForceDiagGrav::diagnose_full() const
   vect_d x(0.), v(0.), l(0.);
   if(snap_shot()->have(fieldbit::q)) {             // IF have external pot      
     LoopAllBodies(snap_shot(),b) {                 //   LOOP bodies             
-      register double mi = mass(b);                //     m                     
+       double mi = mass(b);                //     m                     
       m  += mi;                                    //     add: total mass       
       vin+= mi * pot(b);                           //     add: int pot energy   
       vex+= mi * pex(b);                           //     add: ext pot energy   
@@ -684,7 +684,7 @@ void ForceDiagGrav::diagnose_full() const
     }                                              //   END LOOP                
   } else {                                         // ELSE: no external pot     
     LoopAllBodies(snap_shot(),b) {                 //   LOOP bodies             
-      register double mi = mass(b);                //     m                     
+       double mi = mass(b);                //     m                     
       m  += mi;                                    //     add: total mass       
       vin+= mi * pot(b);                           //     add: int pot energy   
       vect_d mx = mi * vect_d(pos(b));             //     m * x                 

--- a/usr/dehnen/falcON/src/public/lib/nemo++.cc
+++ b/usr/dehnen/falcON/src/public/lib/nemo++.cc
@@ -155,7 +155,7 @@ double falcON::getdparam(const char*p) {
 
 falcON::vect falcON::getvparam(const char*p) {
   vect X;
-  int  N = nemoinp(getparam(p), static_cast<real*>(X), Ndim);
+  int  N = nemoinp(getparam(p), X.data(), Ndim);
   if(N!=Ndim) {
     if(N<0) falcON_THROW("parse error: processing parameter \"%s\"\n",p);
     else    falcON_THROW("parameter \"%s\" requires %d values, but %d given\n",
@@ -166,7 +166,7 @@ falcON::vect falcON::getvparam(const char*p) {
 
 falcON::vect falcON::getvrparam(const char* p) {
   vect X;
-  int  N = nemoinp(getparam(p), static_cast<real*>(X), Ndim);
+  int  N = nemoinp(getparam(p), X.data(), Ndim);
   if(N==1) for(int d=1; d!=Ndim; ++d) X[d]=X[0];
   else if(N!=Ndim) {
     if(N<0) falcON_THROW("parse error: processing parameter \"%s\"\n",p);
@@ -178,7 +178,7 @@ falcON::vect falcON::getvrparam(const char* p) {
 
 falcON::vect* falcON::getvparam_z(const char* p, vect&X) {
   if(!hasvalue(p)) return 0;
-  int N = nemoinp(getparam(p), static_cast<real*>(X), Ndim);
+  int N = nemoinp(getparam(p), X.data(), Ndim);
   if(Ndim != N) {
     if(N<0) falcON_THROW("parse error: processing parameter \"%s\"\n",p);
     else  falcON_Warning("parameter \"%s\" requires %d values, but %d given\n",
@@ -190,7 +190,7 @@ falcON::vect* falcON::getvparam_z(const char* p, vect&X) {
 
 falcON::vect* falcON::getvrparam_z(const char* p, vect&X) {
   if(!hasvalue(p)) return 0;
-  int  N = nemoinp(getparam(p), static_cast<real*>(X), Ndim);
+  int  N = nemoinp(getparam(p), X.data(), Ndim);
   if(N==1) for(int d=1; d!=Ndim; ++d) X[d]=X[0];
   else if(N!=Ndim) {
     if(N<0) falcON_THROW("parse error: processing parameter \"%s\"\n",p);

--- a/usr/dehnen/falcON/src/public/lib/profile.cc
+++ b/usr/dehnen/falcON/src/public/lib/profile.cc
@@ -131,7 +131,7 @@ spherical_profile::spherical_profile(const bodies*B,
   double mcum=0.;                                  // cumulate mass             
   int j=0;                                         // body index                
   for(int i=0; i!=n; ++i) {                        // LOOP bins                 
-    register int 
+     int 
       s  = i==0? ir[i+1]+1 : ir[i+1]+ir[i-1],      //   lower + upper rank      
       sh = s/2;                                    //   mean rank               
     for(; j!=sh; ++j)                              //   LOOP ranks up to mean   
@@ -293,7 +293,7 @@ mr(0), rr(0), sd(0), vl(0), vr(0), sl(0), ba(0), ph(0), al(0)
   double mcum=0.;                                  // cumulate mass             
   int j=0;                                         // body index                
   for(int i=0; i!=n; ++i) {                        // LOOP bins                 
-    register int 
+     int 
       s  = i==0? ir[i+1]+1 : ir[i+1]+ir[i-1],      //   lower + upper rank      
       sh = s/2;                                    //   mean rank               
     for(; j!=sh; ++j)                              //   LOOP ranks up to mean   

--- a/usr/dehnen/falcON/src/public/lib/profile.cc
+++ b/usr/dehnen/falcON/src/public/lib/profile.cc
@@ -198,7 +198,7 @@ spherical_profile::spherical_profile(const bodies*B,
       ba[i] = sqrt(ID[1]/ID[0]);
       xa[i] = vect_d(IV[0][0],IV[1][0],IV[2][0]);
       xi[i] = vect_d(IV[0][2],IV[1][2],IV[2][2]);
-      vect_d erot = norm(Mvp)>0.? normalized(Mvp) : vect_d(0.,0.,1.);
+      vect_d erot = norm(Mvp)>0.? normalised(Mvp) : vect_d(0.,0.,1.);
       double Mvpq(0.), Mvtq(0.);
       for(j=i? ir[i-1]:0; j<=ir[i+1]; ++j) {       // 2nd LOOP of bodies in bin 
 	double mi  = ((i!=0 && j==ir[i-1])  ||  j==ir[i+1]) ?
@@ -207,8 +207,8 @@ spherical_profile::spherical_profile(const bodies*B,
 	vect_d vi  = v0? B->vel(I[j])-(*v0) : B->vel(I[j]);
 	if(R[j]>zero) {
 	  vect_d er  = ri/R[j];
-	  vect_d ep  = normalized(er^erot);
-	  vect_d et  = normalized(er^ep);
+	  vect_d ep  = normalised(er^erot);
+	  vect_d et  = normalised(er^ep);
 	  Mvpq += mi * square(vi*ep);
 	  Mvtq += mi * square(vi*et);
 	}
@@ -252,13 +252,13 @@ projected_profile::projected_profile(const bodies*B,
 				     const vect  *x0,
 				     const vect  *v0)
   falcON_THROWING :
-kmin(__nmin/2), dmax(0.5*__dmax), elos(normalized(__proj)),
+kmin(__nmin/2), dmax(0.5*__dmax), elos(normalised(__proj)),
 mr(0), rr(0), sd(0), vl(0), vr(0), sl(0), ba(0), ph(0), al(0)
 {
   if(elos == 0.)
     falcON_THROW("projected_profile: projection along null vector\n");
   vect_d eY = elos == vect_d(1.,0.,0.) ?
-    normalized(elos ^ vect_d(0.,0.,1.)) : normalized(elos ^ vect_d(1.,0.,0.));
+    normalised(elos ^ vect_d(0.,0.,1.)) : normalised(elos ^ vect_d(1.,0.,0.));
   vect_d eX = eY ^ elos;
   if(!B->have_all(fieldset(fieldset::m|fieldset::x)))
     falcON_THROW("projected_profile: need \"mx\" to estimate density\n");

--- a/usr/dehnen/falcON/src/public/lib/sample.cc
+++ b/usr/dehnen/falcON/src/public/lib/sample.cc
@@ -55,7 +55,7 @@ inline void SphericalSampler::setis()
   const double de =Pi/Ne1;
   double _eta = 0.;
   _p = 1-b0-b0;
-  for(register int i=1; i!=Ne; ++i) {
+  for( int i=1; i!=Ne; ++i) {
     Is[i]    = rk4(Is[i-1],_eta,de,dI);
     _eta   += de;
     Xe[i][0] = sin(_eta);
@@ -203,7 +203,7 @@ void SphericalSampler::sample(body   const&B0,
     for(int i=0; i!=n && Bi!=BN; ++i,++k,++Bi) {
       Bi.mass() = mu;
       Mcum     += mu;
-      register double
+       double
 	cth = q? R(2,-1.,1.):R(-1.,1.),
 	sth = std::sqrt(1.-cth*cth),
 	phi = q? R(3,0.,TPi):R(0.,TPi),
@@ -212,7 +212,7 @@ void SphericalSampler::sample(body   const&B0,
       Bi.pos()[0] = r * sth * cph;
       Bi.pos()[1] = r * sth * sph;
       Bi.pos()[2] = r * cth;
-      register double
+       double
 	psi = q? R(4,0.,TPi):R(0.,TPi),
         vth = vt * std::cos(psi),
         vph = vt * std::sin(psi),

--- a/usr/dehnen/falcON/src/public/lib/tools.cc
+++ b/usr/dehnen/falcON/src/public/lib/tools.cc
@@ -92,9 +92,9 @@ void falcON::find_centre_alpha(const bodies*B,
     W = 0.;                                        //   reset Sum w_i           
     X = 0.;                                        //   reset Sum w_i x_i       
     N = 0u;                                        //   reset # bodies          
-    register double Q(0.);                         //   reset Sum w_i x^2_i     
+     double Q(0.);                         //   reset Sum w_i x^2_i     
     LoopSubsetBodies(B,b) {                        //   LOOP bodies             
-      register double w = weight(b,alpha);         //     w_i = m_i*p_i^alpha   
+       double w = weight(b,alpha);         //     w_i = m_i*p_i^alpha   
       W+= w;                                       //     Sum w_i               
       X+= w * vect_d(pos(b));                      //     Sum w_i x_i           
       Q+= w * norm(pos(b));                        //     Sum w_i x_i^2         
@@ -115,7 +115,7 @@ void falcON::find_centre_alpha(const bodies*B,
     N = 0u;                                        //   reset # bodies          
     LoopSubsetBodies(B,b)                          //   LOOP bodies             
       if(dist_sq(pos(b),Xc) < Rq) {                //     IF |X-Xc| < R         
-	register double w = weight(b,alpha);       //       w_i = m_i*p_i^alpha 
+	 double w = weight(b,alpha);       //       w_i = m_i*p_i^alpha 
 	W+= w;                                     //       Sum w_i             
 	X+= w * vect_d(pos(b));                    //       Sum w_i x_i         
 	N++;                                       //       count               
@@ -132,7 +132,7 @@ void falcON::find_centre_alpha(const bodies*B,
     LoopSubsetBodies(B,b)                          //   LOOP bodies             
       if(dist_sq(pos(b),Xc) < Rq) {                //     IF |X-Xc| < R         
 	M+= mass(b);                               //       Sum m_i             
-	register double w = weight(b,alpha);       //       w_i = m_i*p_i^alpha 
+	 double w = weight(b,alpha);       //       w_i = m_i*p_i^alpha 
 	W+= w;                                     //       Sum w_i             
 	V+= w * vect_d(vel(b));                    //       Sum w_i v_i         
       }                                            //   END LOOP                
@@ -187,7 +187,7 @@ void falcON::estimate_density_peak(OctTree *TREE,
   DensCell_iter max_cell;
   real          rho_max = zero;
   LoopCellsUp(DensCell_iter,TREE,Ci) {
-    register real w=0.;
+     real w=0.;
     LoopLeafKids(DensCell_iter,Ci,l) w += wght(l);
     LoopCellKids(DensCell_iter,Ci,c) w += wght(c);
     Ci->wght() = w;
@@ -217,13 +217,13 @@ namespace {
   template<> struct ferrers<3> {
     static double norm() { return FPi / 19.6875; }
     static void   diff(double const&m, double const&xq, double D[3]) {
-      register double t = 1.-xq, d=m*t, d2=d*t, d3=d2*t;
+       double t = 1.-xq, d=m*t, d2=d*t, d3=d2*t;
       D[2] = 24*d;
       D[1] =-6*d2;
       D[0] = d3;
     }
     static void   diff1(double const&m, double const&xq, double D[2]) {
-      register double t = 1.-xq, d2=m*t*t, d3=d2*t;
+       double t = 1.-xq, d2=m*t*t, d3=d2*t;
       D[1] =-6*d2;
       D[0] = d3;
     }
@@ -293,8 +293,8 @@ namespace {
   {
     const double rq = r*r, irq=1./rq;
     const double hqirq = norm(h) * irq;
-    register double _d1 = 0.;
-    register double _d2 = 0.;
+     double _d1 = 0.;
+     double _d2 = 0.;
     LoopSubsetBodies(B,b) {
       vect_d R(x); R -= pos(b);
       double tmp = norm(R);

--- a/usr/dehnen/falcON/src/public/lib/tree.cc
+++ b/usr/dehnen/falcON/src/public/lib/tree.cc
@@ -475,8 +475,8 @@ namespace {
   }
 } // namespace {
 ////////////////////////////////////////////////////////////////////////////////
-falcON_TRAITS(::dot,"{tree.cc}::dot");
-falcON_TRAITS(::box,"{tree.cc}::box");
+falcON_TRAITS(struct dot,"{tree.cc}::dot");
+falcON_TRAITS(struct box,"{tree.cc}::box");
 ////////////////////////////////////////////////////////////////////////////////
 namespace {
   //////////////////////////////////////////////////////////////////////////////
@@ -1114,7 +1114,7 @@ namespace {
   void TreeBuilder::report_infnan() const falcON_THROWING
   {
     for(const dot*D=D0; D!=DN; ++D)
-      if(D->pos().isinf() || D->pos().isnan())
+      if(isinf(D->pos()) || isnan(D->pos()))
 	falcON_THROW("TreeBuilder: body %d: x=%g,%g,%g\n",
 		     TREE->my_bodies()->bodyindex(D->LINK),
 		     D->pos()[0],D->pos()[1],D->pos()[2]);
@@ -1147,7 +1147,7 @@ namespace {
       }
     DN    = Di;
     XAVE /= real(DN-D0);
-    if(XAVE.isnan() || XAVE.isinf()) report_infnan();
+    if(isnan(XAVE) || isinf(XAVE)) report_infnan();
     if(xmin) XMIN = *xmin;
     if(xmax) XMAX = *xmax;
   }
@@ -1183,7 +1183,7 @@ namespace {
 	}
     DN    = Di;
     XAVE /= real(DN-D0);
-    if(XAVE.isnan() || XAVE.isinf()) report_infnan();
+    if(isnan(XAVE) || isinf(XAVE)) report_infnan();
   }
   //----------------------------------------------------------------------------
   // constructor 1                                                              

--- a/usr/dehnen/falcON/src/public/manip/add_plummer.cc
+++ b/usr/dehnen/falcON/src/public/manip/add_plummer.cc
@@ -82,17 +82,17 @@ namespace falcON { namespace Manipulate {
     void draw(double&r, double&vr, double&vt) const
     {
       // 1. get radius from cumulative mass
-      register double x = std::pow(Ran(),0.66666666666666666667), P = 1-x;
+       double x = std::pow(Ran(),0.66666666666666666667), P = 1-x;
       r = std::sqrt(x/P);
       // 2. get velocity using rejection method
-      register double ve= std::sqrt(2*P), f0= std::pow(P,3.5),f,v;
+       double ve= std::sqrt(2*P), f0= std::pow(P,3.5),f,v;
       do {
 	v = ve * std::pow(Ran(),0.333333333333333333333);
 	f = std::pow(P-0.5*v*v,3.5);
       } while(f0 * Ran() > f);
       r *= R;
       v *= V;
-      register double c = Ran(-1.,1.);
+       double c = Ran(-1.,1.);
       vr = v * c;
       vt = v * std::sqrt(1.-c*c);
     }
@@ -103,7 +103,7 @@ namespace falcON { namespace Manipulate {
       double r,vr,vt;
       draw(r,vr,vt);
       // 2. set position
-      register double
+       double
 	cth = Ran(-1.,1.),
 	sth = std::sqrt(1.-cth*cth),
 	phi = Ran(0.,TPi),
@@ -113,7 +113,7 @@ namespace falcON { namespace Manipulate {
       pos[1] = r * sth * sph;
       pos[2] = r * cth;
       // 2. set velocity
-      register double
+       double
 	psi = Ran(0.,TPi),
 	vth = vt * std::cos(psi),
 	vph = vt * std::sin(psi),

--- a/usr/dehnen/falcON/src/public/manip/dens_centre.cc
+++ b/usr/dehnen/falcON/src/public/manip/dens_centre.cc
@@ -188,7 +188,7 @@ namespace falcON { namespace Manipulate {
 	    << std::setw(15) << std::setprecision(8) << VCEN[1]   << ' '
 	    << std::setw(15) << std::setprecision(8) << VCEN[2]   << "  "
 	    << std::setw(15) << std::setprecision(8) << RHO       << std::endl;
-      // register pointers to centre
+      //  pointers to centre
       S->set_pointer(&XCEN,"xcen");
       S->set_pointer(&VCEN,"vcen");
     } else {

--- a/usr/dehnen/falcON/src/public/manip/density.cc
+++ b/usr/dehnen/falcON/src/public/manip/density.cc
@@ -36,7 +36,7 @@
 // v 0.4.1  20/05/2008  WD renamed routine from neighbour.h
 // v 0.4.2  11/06/2008  WD new DebugInfo and falcON_Warning
 // v 0.4.3  25/09/2008  WD debugged (debug output only)
-// v 0.5    05/11/2008  WD register time of manipulation under trho
+// v 0.5    05/11/2008  WD time of manipulation under trho
 // v 0.5.1  13/04/2010  WD removed use of initial_time()
 // v 0.6    25/06/2010  WD manipulation if time=integer*step (or step==0)
 ////////////////////////////////////////////////////////////////////////////////

--- a/usr/dehnen/falcON/src/public/manip/densprof.cc
+++ b/usr/dehnen/falcON/src/public/manip/densprof.cc
@@ -313,7 +313,7 @@ namespace falcON { namespace Manipulate {
 	  double mi = SHOT->mass(T[i]);
 	  vect_d ri = SHOT->pos(T[i]) - X0;
 	  vect_d vi = SHOT->vel(T[i]) - V0;
-	  vect_d er = normalized(ri);
+	  vect_d er = normalised(ri);
 	  Mvp      += mi * (er^vi);
 	  Rq[j]     = norm(ri);
 	  Mi[j]     = mi;
@@ -333,15 +333,15 @@ namespace falcON { namespace Manipulate {
 	Rm = sqrt( (FP.Position(Lo)*(Mhi-Mh) +
 		    FP.Position(Hi)*(Mh-Mlo) ) / (Mhi-Mlo) );
 	// 4.3.3 measure for all accumulated: mean velocities and dispersion
-	vect_d erot = norm(Mvp)>0.? normalized(Mvp) : vect_d(0.,0.,1.);
+	vect_d erot = norm(Mvp)>0.? normalised(Mvp) : vect_d(0.,0.,1.);
 	double Mvr(0.), Mvrq(0.), Mvpq(0.), Mvtq(0.);
 	for(unsigned i=Cum0; i!=CumK; ++i) {
 	  double mi = SHOT->mass(T[i]);
 	  vect_d ri = SHOT->pos(T[i]) - X0;
 	  vect_d vi = SHOT->vel(T[i]) - V0;
-	  vect_d er = normalized(ri);
-	  vect_d ep = normalized(er^erot);
-	  vect_d et = normalized(er^ep);
+	  vect_d er = normalised(ri);
+	  vect_d ep = normalised(er^erot);
+	  vect_d et = normalised(er^ep);
 	  double ui = er*vi;
 	  Mvr      += mi * ui;
 	  Mvrq     += mi * ui*ui;

--- a/usr/dehnen/falcON/src/public/manip/randomize_azimuth.cc
+++ b/usr/dehnen/falcON/src/public/manip/randomize_azimuth.cc
@@ -55,14 +55,14 @@ namespace falcON { namespace Manipulate {
     const Random3 Ran;
     //--------------------------------------------------------------------------
     static void rotate(vect&x, real const&c, real const&s) {
-      register real 
+       real 
 	t0 = c*x[0] + s*x[1];
       x[1] = c*x[1] - s*x[0];
       x[0] = t0;
     }
     //--------------------------------------------------------------------------
     static void rotate(vect&x, vect const&o, real const&c, real const&s) {
-      register real 
+       real 
 	t0 = o[0] + c*(x[0]-o[0]) + s*(x[1]-o[1]);
       x[1] = o[1] + c*(x[1]-o[1]) - s*(x[0]-o[0]);
       x[0] = t0;

--- a/usr/dehnen/utils/inc/inline.h
+++ b/usr/dehnen/utils/inc/inline.h
@@ -165,8 +165,8 @@ namespace WDutils {
   template<typename _Tp> inline
   _Tp pow(const _Tp &x, unsigned int n) {
     if(n==0) return _Tp(1);
-    register _Tp z=x, y=(n%2)? x : _Tp(1);
-    for(register unsigned int i=n>>1; i; i>>=1) { z*=z; if(i%2) y*=z; }
+     _Tp z=x, y=(n%2)? x : _Tp(1);
+    for( unsigned int i=n>>1; i; i>>=1) { z*=z; if(i%2) y*=z; }
     return y;
   }
   template<typename _Tp> inline

--- a/usr/dehnen/utils/inc/random.h
+++ b/usr/dehnen/utils/inc/random.h
@@ -145,6 +145,7 @@ namespace WDutils {
     mutable unsigned long ix;
     unsigned              actl,bits;
     unsigned long         *v;
+    unsigned long         *v_allocated;
     double                fac;
   public:
     /// which sequence is ours?

--- a/usr/dehnen/utils/inc/tupel.h
+++ b/usr/dehnen/utils/inc/tupel.h
@@ -174,7 +174,7 @@ namespace WDutils {
       /// from 2 elements (for N=2)
       tupel(X x0, X x1)
       {
-	WDutilsStaticAssert(N==2);
+	static_assert(N==2, "Static assertion failed");
 	a[0]=x0;
 	a[1]=x1;
       }

--- a/usr/dehnen/utils/inc/tupel.h
+++ b/usr/dehnen/utils/inc/tupel.h
@@ -181,7 +181,7 @@ namespace WDutils {
       /// from 3 elements (for N=3)
       tupel(X x0, X x1, X x2)
       {
-	WDutilsStaticAssert(N==3);
+	static_assert(N==3, "Static assertion failed");
 	a[0]=x0;
 	a[1]=x1;
 	a[2]=x2;
@@ -189,7 +189,7 @@ namespace WDutils {
       /// from 4 elements (for N=4)
       tupel(X x0, X x1, X x2, X x3)
       {
-	WDutilsStaticAssert(N==4);
+	static_assert(N==4, "Static assertion failed");
 	a[0]=x0;
 	a[1]=x1;
 	a[2]=x2;
@@ -198,7 +198,7 @@ namespace WDutils {
       /// from 5 elements (for N=5)
       tupel(X x0, X x1, X x2, X x3, X x4)
       {
-	WDutilsStaticAssert(N==5);
+	static_assert(N==5, "Static assertion failed");
 	a[0]=x0;
 	a[1]=x1;
 	a[2]=x2;
@@ -208,7 +208,7 @@ namespace WDutils {
       /// from 6 elements (for N=6)
       tupel(X x0, X x1, X x2, X x3, X x4, X x5)
       { 
-	WDutilsStaticAssert(N==6);
+	static_assert(N==6, "Static assertion failed");
 	a[0]=x0;
 	a[1]=x1;
 	a[2]=x2;
@@ -219,7 +219,7 @@ namespace WDutils {
       /// from 7 elements (for N=7)
       tupel(X x0, X x1, X x2, X x3, X x4, X x5, X x6)
       {
-	WDutilsStaticAssert(N==7);
+	static_assert(N==7, "Static assertion failed");
 	a[0]=x0;
 	a[1]=x1;
 	a[2]=x2;
@@ -231,7 +231,7 @@ namespace WDutils {
       /// from 8 elements (for N=8)
       tupel(X x0, X x1, X x2, X x3, X x4, X x5, X x6, X x7)
       {
-	WDutilsStaticAssert(N==8);
+	static_assert(N==8, "Static assertion failed");
 	a[0]=x0;
 	a[1]=x1;
 	a[2]=x2;
@@ -243,7 +243,7 @@ namespace WDutils {
       }
       /// from 9 elements (for N=9)
       tupel(X x0, X x1, X x2, X x3, X x4, X x5, X x6, X x7, X x8) {
-	WDutilsStaticAssert(N==9);
+	static_assert(N==9, "Static assertion failed");
 	a[0]=x0;
 	a[1]=x1;
 	a[2]=x2;
@@ -257,7 +257,7 @@ namespace WDutils {
       /// from 10 elements (for N=10)
       tupel(X x0, X x1, X x2, X x3, X x4, X x5, X x6, X x7, X x8, X x9) 
       {
-	WDutilsStaticAssert(N==10);
+	static_assert(N==10, "Static assertion failed");
 	a[0]=x0;
 	a[1]=x1;
 	a[2]=x2;

--- a/usr/dehnen/utils/make.clang
+++ b/usr/dehnen/utils/make.clang
@@ -17,6 +17,11 @@ PLATFORM 	:= $(shell uname -m)
 empty:=
 space:= $(empty) $(empty)
 
+# detect default c++ standard supported
+CXX_STD_DEFAULT := $(shell $(CXX) -dM -E -x c++ /dev/null | grep __cplusplus | awk '{print $$3}')
+stddefault:
+	@echo "OSTYPE = " $(CXX_STD_DEFAULT)
+
 # detect OSTYPE (Linux or Darwin) 
 OSTYPE := $(shell uname)
 ostype:
@@ -24,7 +29,7 @@ ostype:
 # set following variable to 1 if gcc > 700
 #API_GCC_7 := $(shell expr `echo $(GCCVERSION)` \>= 700)
 
-STDAPI=#-std=c++03
+STDAPI=-std=c++11#-std=c++17#-std=c++03
 
 # warning flags
 ifdef LIMITED_WARNINGS
@@ -38,16 +43,12 @@ WARNING		+= -Wold-style-cast
 endif
 endif
 #WARNING		+= -Wno-unknown-pragmas 
-WARNING += -Wno-unused-command-line-argument -Wno-redeclared-class-member
+WARNING += -Wno-unused-command-line-argument -Wno-redeclared-class-member -Wno-deprecated-declarations -Wno-dangling-else -Wno-return-stack-address
 # it seem that coverage (to be combined with gcov) does not work for openmp)
 #ifdef WDutilsDevel
 #PROFLAGS	:= --coverage -fprofile-use -Wcoverage-mismatch
 #endif
 # general optimisation and warning flags
-OPTFLAGS	:= -mfpmath=sse \
-		$(WARNING) -O2 -fPIC \
-		-funroll-loops -fforce-addr $(PROFLAGS) $(RDYNAMIC)
-
 ifeq ($(NO_ARCH_NATIVE),1)
    ARCH_NATIVE =
 else
@@ -57,6 +58,10 @@ endif
 ifneq ($(OSTYPE),Darwin)
 OPTFLAGS	+= -rdynamic $(ARCH_NATIVE)
 endif
+
+OPTFLAGS	+= \
+		$(WARNING) -O2 -fPIC \
+		-funroll-loops -fforce-addr $(PROFLAGS) $(RDYNAMIC)
 
 # these are actually to be set
 CFLAGS		:= $(OPTFLAGS)

--- a/usr/dehnen/utils/make.clang
+++ b/usr/dehnen/utils/make.clang
@@ -24,13 +24,13 @@ ostype:
 # set following variable to 1 if gcc > 700
 #API_GCC_7 := $(shell expr `echo $(GCCVERSION)` \>= 700)
 
-STDAPI=-std=c++03
+STDAPI=#-std=c++03
 
 # warning flags
 ifdef LIMITED_WARNINGS
-WARNING		:= $(LIMITED_WARNINGS) -Wshadow -Wno-format-security -Wno-unused-variable -Wno-unused-parameter -Wno-redeclared-class-member -Wno-c++11-compat-deprecated-writable-strings -Wno-shadow
+WARNING		:= #$(LIMITED_WARNINGS) -Wshadow -Wno-format-security -Wno-unused-variable -Wno-unused-parameter -Wno-redeclared-class-member -Wno-c++11-compat-deprecated-writable-strings -Wno-shadow
 else
-WARNING		:= -Wextra -Winit-self -Wshadow -Wno-format-security -Wno-unused-variable -Wno-unused-parameter -Wno-redeclared-class-member -Wno-c++11-compat-deprecated-writable-strings -Wno-shadow
+WARNING		:= #-Wextra -Winit-self -Wshadow -Wno-format-security -Wno-unused-variable -Wno-unused-parameter -Wno-redeclared-class-member -Wno-c++11-compat-deprecated-writable-strings -Wno-shadow
 endif
 ifndef TBBROOT
 ifdef WDutilsDevel
@@ -38,7 +38,7 @@ WARNING		+= -Wold-style-cast
 endif
 endif
 #WARNING		+= -Wno-unknown-pragmas 
-
+WARNING += -Wno-unused-command-line-argument -Wno-redeclared-class-member
 # it seem that coverage (to be combined with gcov) does not work for openmp)
 #ifdef WDutilsDevel
 #PROFLAGS	:= --coverage -fprofile-use -Wcoverage-mismatch

--- a/usr/dehnen/utils/make.gcc
+++ b/usr/dehnen/utils/make.gcc
@@ -45,7 +45,7 @@ API_GCC_7 := $(shell expr `echo $(GCCVERSION)` \>= 700)
 
 # c++98 c++03 c++11 c++14 c++17 c++20
 ifeq "$(API_GCC_7)" "1"
-    STDAPI=#-std=c++14#-std=c++03
+    STDAPI=-std=c++11#-std=c++14#-std=c++03
 else
     STDAPI=
 endif
@@ -72,10 +72,7 @@ WARNING		:= #-Wextra -Winit-self -Wshadow -Wno-format-security -Wno-misleading-i
 # OPTFLAGS	:= -mfpmath=sse -mpreferred-stack-boundary=4 
 #OPTFLAGS	:= -mfpmath=sse 
 #OPTFLAGS	:= \
-		--param inline-unit-growth=50
-OPTFLAGS	:= $(WARNING) -O2 -fPIC \
-		-funroll-loops -fforce-addr $(PROFLAGS) $(RDYNAMIC)
-
+		#--param inline-unit-growth=50
 ifeq ($(NO_ARCH_NATIVE),1)
    ARCH_NATIVE =
 else
@@ -84,7 +81,12 @@ endif
 
 ifneq ($(OSTYPE),Darwin)
 OPTFLAGS	+= -rdynamic $(ARCH_NATIVE)
+else
+WARNING         += -Wno-redeclared-class-member -Wno-deprecated-declarations -Wno-dangling-else -Wno-return-stack-address
 endif
+
+OPTFLAGS	:= $(WARNING) -O2 -fPIC \
+		-funroll-loops -fforce-addr $(PROFLAGS) $(RDYNAMIC)
 
 # these are actually to be set
 CFLAGS		:= $(OPTFLAGS)

--- a/usr/dehnen/utils/make.gcc
+++ b/usr/dehnen/utils/make.gcc
@@ -62,7 +62,7 @@ WARNING		+= -Wold-style-cast
 endif
 endif
 #WARNING		+= -Wno-unknown-pragmas
-WARNING		:= -Wextra -Winit-self -Wshadow -Wno-format-security -Wno-misleading-indentation -Wno-deprecated -Wno-expansion-to-defined -Wno-write-strings
+WARNING		:= #-Wextra -Winit-self -Wshadow -Wno-format-security -Wno-misleading-indentation -Wno-deprecated -Wno-expansion-to-defined -Wno-write-strings
 
 # it seem that coverage (to be combined with gcov) does not work for openmp)
 #ifdef WDutilsDevel
@@ -73,7 +73,7 @@ WARNING		:= -Wextra -Winit-self -Wshadow -Wno-format-security -Wno-misleading-in
 #OPTFLAGS	:= -mfpmath=sse 
 #OPTFLAGS	:= \
 		--param inline-unit-growth=50
-OPTFLAGS	:= -ggdb3 $(WARNING) -O2 -fPIC \
+OPTFLAGS	:= $(WARNING) -O2 -fPIC \
 		-funroll-loops -fforce-addr $(PROFLAGS) $(RDYNAMIC)
 
 ifeq ($(NO_ARCH_NATIVE),1)

--- a/usr/dehnen/utils/make.gcc
+++ b/usr/dehnen/utils/make.gcc
@@ -45,16 +45,16 @@ API_GCC_7 := $(shell expr `echo $(GCCVERSION)` \>= 700)
 
 # c++98 c++03 c++11 c++14 c++17 c++20
 ifeq "$(API_GCC_7)" "1"
-    STDAPI=-std=c++03
+    STDAPI=-std=c++14#-std=c++03
 else
     STDAPI=
 endif
 
 # warning flags
 ifdef LIMITED_WARNINGS
-WARNING		:= -Wall $(LIMITED_WARNINGS) -Wshadow -Wno-format-security -Wno-misleading-indentation -Wno-cast-function-type -Wno-format-overflow -Wno-c++11-compat-deprecated-writable-strings -Wno-redeclared-class-member
+WARNING		:= $(LIMITED_WARNINGS) -Wshadow -Wno-format-security -Wno-misleading-indentation -Wno-cast-function-type -Wno-format-overflow -Wno-c++11-compat-deprecated-writable-strings -Wno-redeclared-class-member -Wno-deprecated
 else
-WARNING		:= -Wall -Wextra -Winit-self -Wshadow -Wno-format-security -Wno-misleading-indentation -Wno-cast-function-type -Wno-format-overflow -Wno-c++11-compat-deprecated-writable-strings -Wno-redeclared-class-member
+WARNING		:= -Wextra -Winit-self -Wshadow -Wno-format-security -Wno-misleading-indentation -Wno-cast-function-type -Wno-format-overflow -Wno-c++11-compat-deprecated-writable-strings -Wno-redeclared-class-member -Wno-deprecated
 endif
 ifndef TBBROOT
 ifdef WDutilsDevel
@@ -62,7 +62,7 @@ WARNING		+= -Wold-style-cast
 endif
 endif
 #WARNING		+= -Wno-unknown-pragmas
-WARNING		:= -Wall -Wextra -Winit-self -Wshadow -Wno-format-security -Wno-misleading-indentation
+WARNING		:= -Wextra -Winit-self -Wshadow -Wno-format-security -Wno-misleading-indentation -Wno-deprecated -Wno-expansion-to-defined -Wno-write-strings
 
 # it seem that coverage (to be combined with gcov) does not work for openmp)
 #ifdef WDutilsDevel

--- a/usr/dehnen/utils/make.gcc
+++ b/usr/dehnen/utils/make.gcc
@@ -45,7 +45,7 @@ API_GCC_7 := $(shell expr `echo $(GCCVERSION)` \>= 700)
 
 # c++98 c++03 c++11 c++14 c++17 c++20
 ifeq "$(API_GCC_7)" "1"
-    STDAPI=-std=c++14#-std=c++03
+    STDAPI=#-std=c++14#-std=c++03
 else
     STDAPI=
 endif

--- a/usr/dehnen/utils/src/random.cc
+++ b/usr/dehnen/utils/src/random.cc
@@ -144,7 +144,8 @@ Sobol::Sobol(int ACTL, unsigned BITS)
   // Finally the direction numbers are Vi = 2^(bits-i) * Mi                     
   unsigned i,i2,ip,l;
   unsigned long vi;
-  v = WDutils_NEW(unsigned long,bits)-1;
+  v_allocated = WDutils_NEW(unsigned long,bits);
+  v = v_allocated - 1;
   for(i=1,i2=2; i<=degs; i++,i2<<=1) {
     if(i2<=poly) 
       vi = 1;
@@ -172,7 +173,7 @@ Sobol::Sobol(int ACTL, unsigned BITS)
 }
 //------------------------------------------------------------------------------
 Sobol::~Sobol() {
-  WDutils_DEL_A(v+1);
+  WDutils_DEL_A(v_allocated);
   sobol_f[actl]  = 0;
 }
 //------------------------------------------------------------------------------


### PR DESCRIPTION
In this branch, the Dehnen code (falcON) is now compatible with the C++17 standard. When compiling, there are practically no more warnings, both with g++ (Linux) and with clang++ on Mac Intel/ARM.

In the make.gcc and make.clang configurations files, I have forced the C++11 standard because some compilers are not yet C++17 compatible.